### PR TITLE
replace outdated text in grouper/lib/custom/README.txt

### DIFF
--- a/grouper/lib/custom/README.txt
+++ b/grouper/lib/custom/README.txt
@@ -14,13 +14,5 @@
     limitations under the License.
 ====
 
-LDAP 3.2 README
-
-    This is the 3.2 release of the VT LDAP Java libraries.
-    It is dual licensed under both the LGPL and Apache 2.
-    If you have questions or comments about this library contact
-    Middleware Services (middleware@vt.edu).
-
-DOCUMENTATION
-    See the wiki: http://code.google.com/p/vt-middleware/wiki/vtldap
+JAR files in this directory will be added to Grouper's class path.
 


### PR DESCRIPTION
Current `README.txt` refers to JAR file that is not present in directory.
