### PR TITLE
GRP-1048: Add extra massageSortFields() calls to fix non-wheel UI

### DIFF
--- a/grouper/src/grouper/edu/internet2/middleware/grouper/internal/dao/hib3/Hib3AttributeDefDAO.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/internal/dao/hib3/Hib3AttributeDefDAO.java
@@ -110,6 +110,9 @@ public class Hib3AttributeDefDAO extends Hib3DAO implements AttributeDefDAO {
    * @see edu.internet2.middleware.grouper.internal.dao.AttributeDefDAO#findById(java.lang.String, boolean, QueryOptions)
    */
   public AttributeDef findById(String id, boolean exceptionIfNotFound, QueryOptions queryOptions) {
+    if (queryOptions != null) {
+      massageSortFields(queryOptions.getQuerySort());
+    }
     AttributeDef attributeDef = HibernateSession.byHqlStatic()
       .setCacheable(true)
       .setCacheRegion(KLASS + ".FindById")
@@ -183,6 +186,9 @@ public class Hib3AttributeDefDAO extends Hib3DAO implements AttributeDefDAO {
    */
   public AttributeDef findByNameSecure(String name, boolean exceptionIfNotFound, QueryOptions queryOptions)
       throws GrouperDAOException, AttributeDefNotFoundException {
+    if (queryOptions != null) {
+      massageSortFields(queryOptions.getQuerySort());
+    }
     AttributeDef attributeDef = HibernateSession.byHqlStatic()
       .createQuery("select a from AttributeDef as a where a.nameDb = :value")
       .setCacheable(true)
@@ -253,6 +259,9 @@ public class Hib3AttributeDefDAO extends Hib3DAO implements AttributeDefDAO {
    */
   public AttributeDef findByUuidOrName(String id, String name,
       boolean exceptionIfNotFound, QueryOptions queryOptions) {
+    if (queryOptions != null) {
+      massageSortFields(queryOptions.getQuerySort());
+    }
     try {
       AttributeDef attributeDef = HibernateSession.byHqlStatic()
         .createQuery("from AttributeDef as theAttributeDef where theAttributeDef.id = :theId or theAttributeDef.nameDb = :theName")


### PR DESCRIPTION
The existing fix for GRP-1048 (errors in the New UI when browsing as a non-wheel user) fails to resolve the problem when using PostgreSQL 9.1 as a backend database.  This is due to the new massageSortFields() method not being called in some cases.

This patch adds calls to massageSortFields() in Hib3AttributeDefDAO methods where they were previously absent to fix this.  The affected methods are:
- findById
- findByNameSecure
- findByUuidOrName
