### PR TITLE
Removed Integer.min which is not in OpenJDK

### DIFF
--- a/grouper-misc/grouper-voot/src/edu/internet2/middleware/grouperVoot/messages/VootResponse.java
+++ b/grouper-misc/grouper-voot/src/edu/internet2/middleware/grouperVoot/messages/VootResponse.java
@@ -49,7 +49,7 @@ public abstract class VootResponse {
       this.startIndex = (start > 0 ) ? start : 0;
       this.totalResults = resultArray.length;
       if (count > 0) {
-        this.itemsPerPage = Integer.min(count, resultArray.length - start);
+        this.itemsPerPage = Math.min(count, resultArray.length - start);
       }
       else {
         this.itemsPerPage = resultArray.length;


### PR DESCRIPTION
Sorry Chris for this new commit.
I've realized that Integer.min is present only in Oracle VM while Math.min is present either in Oracle JVM and in OpenJDK.
