### PR TITLE
Fixed amq build with path to grouper client jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@ subject/doc/
 **/build/dist/**/*.jar
 grouper-ws/grouper-ws/build/*
 grouper-ws/grouper-ws/webapp/WEB-INF/lib/*
+grouper-misc/grouperActivemq/dist2/

--- a/grouper-misc/grouperActivemq/build.example.properties
+++ b/grouper-misc/grouperActivemq/build.example.properties
@@ -1,1 +1,2 @@
-
+#put the grouperClient jar dir here
+grouperClient.dir = ../grouperClient/dist

--- a/grouper-misc/grouperActivemq/build.xml
+++ b/grouper-misc/grouperActivemq/build.xml
@@ -39,6 +39,10 @@
       <fileset dir="libCompile">
         <include name="**/*.jar" />
       </fileset>
+      <fileset dir="${grouperClient.dir}">
+        <include name="**/*.jar" />
+      </fileset>
+
     </path>
 
   </target>


### PR DESCRIPTION
Fixes the amq module build with `ant grouper-amq`. the client jar must be added to the classpath