### PR TITLE
GRP-1118 Revoking all privs from group

### DIFF
--- a/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/serviceLogic/UiV2Group.java
+++ b/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/serviceLogic/UiV2Group.java
@@ -1126,20 +1126,31 @@ public class UiV2Group {
       }
       
       int changes = 0;
-      
-      Privilege[] privileges = assignAll ? (assign ? new Privilege[]{  
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_ADMINS)} : new Privilege[]{  
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_ADMINS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_GROUP_ATTR_READERS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_GROUP_ATTR_UPDATERS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_OPTOUTS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_READERS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_VIEWERS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_UPDATERS),
-          AccessPrivilege.listToPriv(Field.FIELD_NAME_OPTINS)
-          } ) : (readersUpdaters ? new Privilege[]{AccessPrivilege.listToPriv(Field.FIELD_NAME_READERS),
-              AccessPrivilege.listToPriv(Field.FIELD_NAME_UPDATERS)
-          } : new Privilege[]{AccessPrivilege.listToPriv(fieldName)});
+
+      Privilege[] privileges = null;
+      if (assignAll) {
+        if (assign) {
+          privileges = new Privilege[]{AccessPrivilege.listToPriv(Field.FIELD_NAME_ADMINS)};
+        } else {
+          privileges = new Privilege[]{
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_GROUP_ATTR_READERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_GROUP_ATTR_UPDATERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_OPTOUTS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_READERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_VIEWERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_UPDATERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_OPTINS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_ADMINS)
+          };
+        }
+      } else {
+        if (readersUpdaters) {
+          privileges = new Privilege[]{AccessPrivilege.listToPriv(Field.FIELD_NAME_READERS),
+                  AccessPrivilege.listToPriv(Field.FIELD_NAME_UPDATERS)};
+        } else {
+          privileges = new Privilege[]{AccessPrivilege.listToPriv(fieldName)};
+        }
+      }
       
       int count = 0;
       for (Member member : members) {
@@ -1174,8 +1185,12 @@ public class UiV2Group {
         
       }
       guiResponseJs.addAction(GuiScreenAction.newScript("guiScrollTop()"));
-  
-      filterPrivilegesHelper(request, response, group);
+
+      if (group.hasAdmin(loggedInSubject)) {
+        filterPrivilegesHelper(request, response, group);
+      } else {
+        guiResponseJs.addAction(GuiScreenAction.newScript("guiV2link('operation=UiV2Main.indexMain')"));
+      }
   
       GrouperUserDataApi.recentlyUsedGroupAdd(GrouperUiUserData.grouperUiGroupNameForUserData(), 
           loggedInSubject, group);


### PR DESCRIPTION
To duplicate the error: 
- As an admin, add a member to a group and assign all privs
- Login as member and browse to privs for the group
- Select member, and then select to batch revoke all privs
- Receive error

It appears that with the above scenario, once the admin priv is removed, subsequent privs fail. This solution re-orders the list of privs that are to be removed, so admin is removed last. Finally, the flow is redirected back to the main page. 