### PR TITLE
GRP-1404: Handle property files inside jars

### DIFF
--- a/grouper/src/grouper/edu/internet2/middleware/grouper/misc/GrouperStartup.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/misc/GrouperStartup.java
@@ -128,9 +128,10 @@ public class GrouperStartup {
 
     StringBuilder resultString = new StringBuilder();
     resultString.append(grouperStartup + "\n");
-    File grouperPropertiesFile = GrouperUtil.fileFromResourceName("grouper.properties");
-    String propertiesFileLocation = grouperPropertiesFile == null ? "not found" 
-        : GrouperUtil.fileCanonicalPath(grouperPropertiesFile); 
+    String propertiesFileLocation = GrouperUtil.getLocationFromResourceName("grouper.properties");
+    if (propertiesFileLocation == null) {
+      propertiesFileLocation = "not found";
+    }
     resultString.append("grouper.properties read from: " + propertiesFileLocation + "\n");
 
     if (GrouperConfig.retrieveConfig().propertyValueBoolean("grouper.api.readonly", false)) {
@@ -139,15 +140,17 @@ public class GrouperStartup {
     
     resultString.append("Grouper current directory is: " + new File("").getAbsolutePath() + "\n");
     //get log4j file
-    File log4jFile = GrouperUtil.fileFromResourceName("log4j.properties");
-    String log4jFileLocation = log4jFile == null ? " [cant find log4j.properties]" :
-      GrouperUtil.fileCanonicalPath(log4jFile);
+    String log4jFileLocation = GrouperUtil.getLocationFromResourceName("log4j.properties");
+    if (log4jFileLocation == null) {
+      log4jFileLocation = " [cant find log4j.properties]";
+    }
     resultString.append("log4j.properties read from:   " + log4jFileLocation + "\n");
     
-    resultString.append(GrouperUtil.logDirPrint());    
-    File hibPropertiesFile = GrouperUtil.fileFromResourceName("grouper.hibernate.properties");
-    String hibPropertiesFileLocation = hibPropertiesFile == null ? " [cant find grouper.hibernate.properties]" :
-      GrouperUtil.fileCanonicalPath(hibPropertiesFile);
+    resultString.append(GrouperUtil.logDirPrint());
+    String hibPropertiesFileLocation = GrouperUtil.getLocationFromResourceName("grouper.hibernate.properties");
+    if (hibPropertiesFileLocation == null) {
+      hibPropertiesFileLocation = " [cant find grouper.hibernate.properties]";
+    }
     resultString.append("grouper.hibernate.properties: " + hibPropertiesFileLocation + "\n");
     
     Properties grouperHibernateProperties = GrouperUtil.propertiesFromResourceName("grouper.hibernate.properties");

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/util/GrouperUtil.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/util/GrouperUtil.java
@@ -1371,6 +1371,38 @@ public class GrouperUtil {
     }
   }
 
+  /**
+   * get a full path from a resource name
+   *
+   * @param resourceName
+   *          is the classpath location
+   *
+   * @return Full path to the resource. For files, the file path on the system; otherwise, the resource URL
+   */
+  public static String getLocationFromResourceName(String resourceName) {
+
+    URL url = computeUrl(resourceName, true);
+
+    if (url == null) {
+      return null;
+    }
+
+    if (url.getProtocol() == "file") {
+      try {
+        String urlFile = URLDecoder.decode(url.getFile(), "UTF-8");
+        return fileCanonicalPath(new File(urlFile));
+      } catch (UnsupportedEncodingException uee) {
+        throw new RuntimeException(uee);
+      }
+    }
+
+    try {
+      String urlPath = URLDecoder.decode(url.toString(), "UTF-8");
+      return urlPath;
+    } catch (UnsupportedEncodingException uee) {
+      throw new RuntimeException(uee);
+    }
+  }
 
   /**
    * compute a url of a resource

--- a/subject/src/edu/internet2/middleware/subject/SubjectUtils.java
+++ b/subject/src/edu/internet2/middleware/subject/SubjectUtils.java
@@ -1916,6 +1916,7 @@ public class SubjectUtils {
    * 
    * @return the file path on the system
    */
+  @Deprecated
   public static File fileFromResourceName(String resourceName) {
     
     URL url = computeUrl(resourceName, true);
@@ -1927,6 +1928,25 @@ public class SubjectUtils {
     File configFile = new File(url.getFile());
   
     return configFile;
+  }
+
+  /**
+   * get a file name from a resource name
+   *
+   * @param resourceName
+   *          is the classpath location
+   *
+   * @return Full path to the resource. For files, the file path on the system; otherwise, the resource URL
+   */
+  public static String getLocationFromResourceName(String resourceName) {
+
+    URL url = computeUrl(resourceName, true);
+
+    if (url == null) {
+      return null;
+    }
+
+    return (url.getProtocol() == "file") ? fileCanonicalPath(new File(url.getFile())) : url.toString();
   }
 
   /**

--- a/subject/src/edu/internet2/middleware/subject/provider/SourceManager.java
+++ b/subject/src/edu/internet2/middleware/subject/provider/SourceManager.java
@@ -207,10 +207,10 @@ public class SourceManager {
     try {
       StringBuilder result = new StringBuilder();
 
-      File sourcesXmlFile = SubjectUtils.fileFromResourceName("sources.xml");
-      String sourcesXmlFileLocation = sourcesXmlFile == null ? " [cant find sources.xml]"
-          : SubjectUtils.fileCanonicalPath(sourcesXmlFile);
-
+      String sourcesXmlFileLocation = SubjectUtils.getLocationFromResourceName("sources.xml");
+      if (sourcesXmlFileLocation == null) {
+        sourcesXmlFileLocation = " [cant find sources.xml]";
+      }
       result.append("sources.xml read from:        " + sourcesXmlFileLocation + "\n");
 
       //at this point, we have a sources.xml...  now check it out


### PR DESCRIPTION
1) In GrouperStartup.printConfigOnce() and SourceManager.printConfig(), don't canonicalize resource paths if the protocol isn't "file" -- resources inside of jars have an included exclamation mark that Windows chokes on

2) For ldapProperties_file files referenced in sources.xml, don't use Java file reading in case they aren't physical filesystem files

Marked SubjectUtils.fileFromResourceName() as deprecated since nothing is invoking it anymore