### PR TITLE
GRP-1428: Implements LDAP Loader validator; add midding validator pro…

### DIFF
--- a/grouper/conf/grouper-loader.base.properties
+++ b/grouper/conf/grouper-loader.base.properties
@@ -226,6 +226,13 @@ grouperLoader.db.connections.pool = true
 #ldap.personLdap.pagedResultsSize = 
 # set to 'follow' if using AD and using paged results size and need this for some reason (generally you shouldnt)
 #ldap.personLdap.referral = 
+# validator setup, choose ConnectLdapValidator or CompareLdapValidator. For
+# CompareLdapValidator, additionally set the dn and search
+#ldap.personLdap.validator = ConnectLdapValidator
+#ldap.personLdap.validator = CompareLdapValidator
+#ldap.personLdap.validatorCompareDn = ou=people,dc=example,dc=com
+#ldap.personLdap.validatorCompareSearchFilterString = (ou=people)
+
 
 
 ##################################

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/GrouperLoaderConfig.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/GrouperLoaderConfig.java
@@ -23,6 +23,11 @@ import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
+import edu.vt.middleware.ldap.Ldap;
+import edu.vt.middleware.ldap.SearchFilter;
+import edu.vt.middleware.ldap.pool.CompareLdapValidator;
+import edu.vt.middleware.ldap.pool.ConnectLdapValidator;
+import edu.vt.middleware.ldap.pool.LdapValidator;
 
 import edu.internet2.middleware.grouper.app.loader.db.GrouperLoaderDb;
 import edu.internet2.middleware.grouper.app.loader.ldap.GrouperLoaderLdapServer;
@@ -303,6 +308,28 @@ public class GrouperLoaderConfig extends ConfigPropertiesCascadeBase  {
       grouperLoaderLdapServer.setValidateOnCheckOut(true);
     }
     
+    //if there is a validation requested, set up the validation class with the ldap factory
+    if (grouperLoaderLdapServer.isValidateOnCheckIn() || grouperLoaderLdapServer.isValidateOnCheckOut() || grouperLoaderLdapServer.isValidatePeriodically()) {
+      LdapValidator<Ldap> validator = null;
+
+      String ldapValidator = getPropertyString("ldap." + name + ".validator");
+
+      if (StringUtils.equalsIgnoreCase(ldapValidator, CompareLdapValidator.class.getSimpleName())) {
+        String validationDn = getPropertyString("ldap." + name + ".validatorCompareDn");
+        String validationSearchFilterString = getPropertyString("ldap." + name + ".validatorCompareSearchFilterString");
+        validator = new CompareLdapValidator(validationDn, new SearchFilter(validationSearchFilterString)); // perform a simple compare
+      } else if (StringUtils.equalsIgnoreCase(ldapValidator, ConnectLdapValidator.class.getSimpleName())) {
+        //this is the default, why not
+        validator = new ConnectLdapValidator(); // perform a simple connect
+      } else if (!StringUtils.isBlank(ldapValidator)) {
+        //get the class
+        Class<LdapValidator<Ldap>> validatorClass = GrouperUtil.forName(ldapValidator);
+        validator = GrouperUtil.newInstance(validatorClass);
+      }
+
+      grouperLoaderLdapServer.setValidator(validator);
+    }
+
     //#ldap.personLdap.validateTimerPeriod = 
     grouperLoaderLdapServer.setValidateTimerPeriod(GrouperLoaderConfig.retrieveConfig().propertyValueInt("ldap." + name + ".validateTimerPeriod", -1));
     

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/ldap/GrouperLoaderLdapServer.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/ldap/GrouperLoaderLdapServer.java
@@ -19,6 +19,8 @@
  */
 package edu.internet2.middleware.grouper.app.loader.ldap;
 
+import edu.vt.middleware.ldap.Ldap;
+import edu.vt.middleware.ldap.pool.LdapValidator;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -115,6 +117,9 @@ public class GrouperLoaderLdapServer {
 
   /** if validating periodically, this is the period in millis */
   private int validateTimerPeriod = -1;
+
+  /** if validating, the validating function */
+  private LdapValidator<Ldap> validator = null;
 
   /** period for which prune timer will run, in millis */
   private int pruneTimerPeriod = -1;
@@ -379,6 +384,23 @@ public class GrouperLoaderLdapServer {
   public void setValidateTimerPeriod(int validateTimerPeriod1) {
     this.validateTimerPeriod = validateTimerPeriod1;
   }
+
+  /**
+   * if validating, the LDAPFactory validator
+   * @param validator
+   */
+  public void setValidator(LdapValidator<Ldap> validator) {
+    this.validator = validator;
+  }
+
+  /**
+   * if validating, the LDAPFactory validator
+   * @return the LDAPFactory validator
+   */
+  public LdapValidator<Ldap> getValidator() {
+    return this.validator;
+  }
+
 
   /**
    * period for which prune timer will run, in millis

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/LdapSession.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/LdapSession.java
@@ -194,7 +194,10 @@ public class LdapSession {
           }
           
           DefaultLdapFactory factory = new DefaultLdapFactory(ldapConfig);
+          factory.setLdapValidator(grouperLoaderLdapServer.getValidator());
+
           blockingLdapPool = new BlockingLdapPool(ldapPoolConfig, factory);
+          blockingLdapPool.initialize();
           poolMap.put(ldapServerId, blockingLdapPool);
         }
       }

--- a/subject/conf/ldap.properties.example
+++ b/subject/conf/ldap.properties.example
@@ -21,3 +21,11 @@ edu.vt.middleware.ldap.bindCredential=admin_password
 # pooling options
 edu.vt.middleware.ldap.pool.minPoolSize = 2
 edu.vt.middleware.ldap.pool.maxPoolSize = 5
+#edu.vt.middleware.ldap.pool.pruneTimerPeriod = 300000
+#edu.vt.middleware.ldap.pool.expirationTime = 600000
+
+# pooling validation, if a validator was set up in sources.xml
+#edu.vt.middleware.ldap.pool.validateOnCheckIn = false
+#edu.vt.middleware.ldap.pool.validateOnCheckOut = false
+#edu.vt.middleware.ldap.pool.validatePeriodically = false
+#edu.vt.middleware.ldap.pool.validateTimerPeriod = 1800000


### PR DESCRIPTION
## Summary

### LDAP Loader

In grouper-loader, LDAP Loader parameter validateOnCheckout gives error (at WARN level): "validate called, but no validator configured". There is no way to turn this off; if all the validator choices are set to false, validateOnCheckout will be set to true due to source code checks.

You don't see this by default because of the default log4j log level of ERROR. There is a commented out logging override for vt-ldap of INFO. If you uncomment this, you can see this error line for every triggered loader group.

Setting validatePeriodically instead of validateOnCheckout avoids this error. But only because the pool's initialize() function is not called, so that the periodic filter is not triggered. Nor is the pruneTimerPeriod timer ever triggered (and expirationTime timer, in case you thought to set this hidden parameter).

There is no current way to set a validator via property files. That's because the validator isn't part of the pool configuration object, but rather set up in the DefaultLdapFactory object.

This pull request sets up validators correctly for use in the LDAP Loader. It does this by adding some "pseudo" properties to grouper-loader.properties that set up the validator object and puts it into the factory:

    ldap.personLdap.validator = CompareLdapValidator (or ConnectLdapValidator)
    ldap.personLdap.validatorCompareDn = ou=people,dc=example,dc=com
    ldap.personLdap.validatorCompareSearchFilterString = (ou=people)

I tested this locally by both network sniffing and turning up the vt-ldap log levels, and the CompareLdapValidator is working as needed. I couldn't see much effect with the ConnectLdapValidator, but I don't know what it's supposed to look like.

### Subject sources

GRP-1151 added functionality to set a validator for LDAP sources in sources.xml. However, if you don't *also* set the validation trigger in ldap.properties, it will never be utilized. My patch just adds commented lines to the ldap.properties.example file, noting the default property settings for it in the pool config, including that all the triggers are false unless you manually enable one.
 
The original request in GRP-1151 was that the user had already added those settings to ldap.properties. But for everyone else, it's not obvious that the sample validator won't trigger without setting up additional properties that aren't documented.
