### PR TITLE
GRP-1440: Add two new UI properties to control skipping of dojo autocompletion

### DIFF
--- a/grouper-ui/conf/grouper-ui.base.properties
+++ b/grouper-ui/conf/grouper-ui.base.properties
@@ -293,6 +293,12 @@ search.default.any=false
 # Control default search option
 search.default=name
 
+# dojo autocompletion for add member/add groups does a wildcard search
+# for every character typed. If defined, only allow this for certain
+# forms. If undefined, allow for all of them
+#uiV2.search.autocompleteById.allowedPaths = /UiV2Subject.addToGroupFilter, /UiV2Stem.createGroupParentFolderFilter, /UiV2Group.addMemberFilter
+#uiV2.search.autocompleteSearch.allowedPaths = /UiV2Subject.addToGroupFilter, /UiV2Stem.createGroupParentFolderFilter, /UiV2Group.addMemberFilter
+
 # Allow filtering of membership lists by subject source
 members.filter.by-source=true
 members.filter.limit=500


### PR DESCRIPTION
The autocompletion of subjects in the group page's add member form does a suffix wildcard search for every character typed after the initial 2 characters. If these queries don't return immediately, it reduces the effectiveness of the autocompletion and also puts a load on the server. With two new properties in grouper-ui.properties

    uiV2.search.autocompleteById.allowedPaths
    uiV2.search.autocompleteSearch.allowedPaths

the autocompletion can be whitelisted for certain pages. If these properties are undefined or blank, the default will be the status quo, which is to allow it on all pages using autocompletion.

The main ones using the dojo JS autocompletion by default are:

  - /UiV2Subject.addToGroupFilter
  - /UiV2Stem.createGroupParentFolderFilter
  - /UiV2Group.addMemberFilter

The first two of these generally hit internal Grouper tables and may perform ok. The last item, addMemberFilter, will hit all of the external subject sources with a wildcard search. First it will search by Id and Identifier with a wildcard suffix in the term. Then it will do a general name search. The name search will **not** contain the wildcard, so it will utilize whatever wildcards are in the subject sources in the "search" query.
