### PR TITLE
GRP-1474: ldap loader set pool options when using configFileFromClasspath

### DIFF
--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/GrouperLoaderConfig.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/loader/GrouperLoaderConfig.java
@@ -303,34 +303,26 @@ public class GrouperLoaderConfig extends ConfigPropertiesCascadeBase  {
 
     grouperLoaderLdapServer.setSearchResultHandlers(GrouperLoaderConfig.retrieveConfig().propertyValueString("ldap." + name + ".searchResultHandlers"));
 
-    grouperLoaderLdapServer.setReferral(getPropertyString("ldap." + name + ".referral"));
+    grouperLoaderLdapServer.setReferral(GrouperLoaderConfig.retrieveConfig().propertyValueString("ldap." + name + ".referral"));
 
-    //#validateOnCheckout defaults to true if all other validate methods are false
-    if (!grouperLoaderLdapServer.isValidateOnCheckIn() && !grouperLoaderLdapServer.isValidateOnCheckOut() && !grouperLoaderLdapServer.isValidatePeriodically()) {
-      grouperLoaderLdapServer.setValidateOnCheckOut(true);
+    LdapValidator<Ldap> validator = null;
+
+    String ldapValidator = getPropertyString("ldap." + name + ".validator");
+
+    if (StringUtils.equalsIgnoreCase(ldapValidator, CompareLdapValidator.class.getSimpleName())) {
+      String validationDn = getPropertyString("ldap." + name + ".validatorCompareDn");
+      String validationSearchFilterString = getPropertyString("ldap." + name + ".validatorCompareSearchFilterString");
+      validator = new CompareLdapValidator(validationDn, new SearchFilter(validationSearchFilterString)); // perform a simple compare
+    } else if (StringUtils.equalsIgnoreCase(ldapValidator, ConnectLdapValidator.class.getSimpleName())) {
+      //this is the default, why not
+      validator = new ConnectLdapValidator(); // perform a simple connect
+    } else if (!StringUtils.isBlank(ldapValidator)) {
+      //get the class
+      Class<LdapValidator<Ldap>> validatorClass = GrouperUtil.forName(ldapValidator);
+      validator = GrouperUtil.newInstance(validatorClass);
     }
-    
-    //if there is a validation requested, set up the validation class with the ldap factory
-    if (grouperLoaderLdapServer.isValidateOnCheckIn() || grouperLoaderLdapServer.isValidateOnCheckOut() || grouperLoaderLdapServer.isValidatePeriodically()) {
-      LdapValidator<Ldap> validator = null;
 
-      String ldapValidator = getPropertyString("ldap." + name + ".validator");
-
-      if (StringUtils.equalsIgnoreCase(ldapValidator, CompareLdapValidator.class.getSimpleName())) {
-        String validationDn = getPropertyString("ldap." + name + ".validatorCompareDn");
-        String validationSearchFilterString = getPropertyString("ldap." + name + ".validatorCompareSearchFilterString");
-        validator = new CompareLdapValidator(validationDn, new SearchFilter(validationSearchFilterString)); // perform a simple compare
-      } else if (StringUtils.equalsIgnoreCase(ldapValidator, ConnectLdapValidator.class.getSimpleName())) {
-        //this is the default, why not
-        validator = new ConnectLdapValidator(); // perform a simple connect
-      } else if (!StringUtils.isBlank(ldapValidator)) {
-        //get the class
-        Class<LdapValidator<Ldap>> validatorClass = GrouperUtil.forName(ldapValidator);
-        validator = GrouperUtil.newInstance(validatorClass);
-      }
-
-      grouperLoaderLdapServer.setValidator(validator);
-    }
+    grouperLoaderLdapServer.setValidator(validator);
 
     //#ldap.personLdap.validateTimerPeriod = 
     grouperLoaderLdapServer.setValidateTimerPeriod(GrouperLoaderConfig.retrieveConfig().propertyValueInt("ldap." + name + ".validateTimerPeriod", -1));


### PR DESCRIPTION
Allows configuration of ldap pool settings via a definition file pulled in from configFileFromClasspath. This brings the functionality in line with sources.xml/subject.properties, which could already set pool options when using an external ldapProperties_file reference.

This also prevents the defaulting of validateOnCheckOut to true when the user hasn't set up a validation function; this prevents the log warning "validate called, but no validator configured".
