### PR TITLE
GRP-1489: Can't type multiple lines in Add Members copy/paste

### DIFF
--- a/grouper-ui/webapp/grouperExternal/public/assets/js/grouperUi.js
+++ b/grouper-ui/webapp/grouperExternal/public/assets/js/grouperUi.js
@@ -2337,9 +2337,9 @@ function hideCustomPrivilege(elementId) {
  */
 function grouperDisableEnterOnCombo(jqueryHandleOfFormElement) {
   var jqueryElement = $(jqueryHandleOfFormElement);
-  if (!jqueryElement.is('form')) {
-    jqueryElement = jqueryElement.closest('form');
-  }
+  //if (!jqueryElement.is('form')) {
+  //  jqueryElement = jqueryElement.closest('form');
+  //}
   if (jqueryElement.length !== 0) {
     jqueryElement.on('keyup keypress', function(e) {
       var keyCode = e.keyCode || e.which;


### PR DESCRIPTION
UI 2.3.0 patch 11 introduced function grouperDisableEnterOnCombo(jqueryHandleOfFormElement) to disable hitting the carriage return to submit the form on certain text fields. This effectively fixed issues with dojo combo fields, but it also broke entry of multiple lines in a textarea, if it was contained in the same form as a dojo text field. Simply removing the lines that broaden the scope to the entire form effectively fixes this issue, leaving carriage return disabling at the level of the caller form field but not effecting other form fields in the same form. The code change in this PR fixes the issue for us.

If feasible, please also create a 2.3.0 patch for this.