### PR TITLE
GRP-1584: WS allow multiple login subject sources

### DIFF
--- a/grouper-ws/grouper-ws/conf/grouper-ws.base.properties
+++ b/grouper-ws/grouper-ws/conf/grouper-ws.base.properties
@@ -52,7 +52,7 @@ ws.act.as.cache.minutes = 30
 ws.client.user.group.cache.minutes = 5
 
 # if you have subject namespace overlap (or not), set the default subject 
-# source to lookup the user if none specified in user name
+# sources (comma-separated) to lookup the user if none specified in user name
 ws.logged.in.subject.default.source = 
 
 # prepend to the userid this value (e.g. if using local entities, might be:    etc:servicePrincipals:   )

--- a/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java
+++ b/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java
@@ -33,6 +33,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import edu.internet2.middleware.subject.SubjectNotFoundException;
 import org.apache.axis2.context.MessageContext;
 import org.apache.commons.collections.keyvalue.MultiKey;
 import org.apache.commons.lang.StringUtils;
@@ -254,9 +255,15 @@ public class GrouperServiceJ2ee implements Filter {
             if (SOURCE_ID == null) {
               return SubjectFinder.findByIdOrIdentifier(USER_ID_LOGGED_IN, true);
             }
-            //see if only in one source
-            return SubjectFinder.findByIdOrIdentifierAndSource(USER_ID_LOGGED_IN, SOURCE_ID, true);
-      
+            //see if in specified sources
+            String[] sourceIds = GrouperUtil.splitTrim(SOURCE_ID, ",");
+            for (String curSource : sourceIds) {
+              Subject s = SubjectFinder.findByIdOrIdentifierAndSource(USER_ID_LOGGED_IN, curSource, false);
+              if (s != null) {
+                return s;
+              }
+            }
+            throw new SubjectNotFoundException("Unable to find subject in source type(s): " + SOURCE_ID);
           } catch (Exception e) {
             //this is probably a system error...  not a user error
             throw new RuntimeException("Cant find subject from login id: " + USER_ID_LOGGED_IN, e);


### PR DESCRIPTION
The grouper-ws.properties parameter ws.logged.in.subject.default.source allows logins to WS from a specific source rather than all of them. This change is to make it a comma-separated list instead of a single value. The use case for this is that either users or service accounts need access.