### PR TITLE
Fix NullPointerException caused in Grouper WS when HttpRequest is nulled

### DIFF
--- a/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java
+++ b/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java
@@ -108,7 +108,10 @@ public class GrouperServiceJ2ee implements Filter {
       HttpServletRequest httpServletRequest, String key) {
     //if no servlet (probably just testing), get from map
     if (httpServletRequest == null) {
-      return paramMap == null ? null : paramMap.get(key)[0];
+      if (paramMap == null || paramMap.isEmpty() || !paramMap.containsKey(key)) {
+        return null;
+      }
+      return paramMap.get(key)[0];
     }
     String[] values = httpServletRequest.getParameterValues(key);
     if (values == null || values.length == 0) {


### PR DESCRIPTION
A GET request to Grouper-WS that contains a request body will cause the following NPE:

```bash
java.lang.NullPointerException
at edu.internet2.middleware.grouper.ws.GrouperServiceJ2ee.parameterValue(GrouperServiceJ2ee.java:111) 
at edu.internet2.middleware.grouper.ws.util.GrouperServiceUtils.marshalHttpParamsToObject(GrouperServiceUtils.java:332)
at edu.internet2.middleware.grouper.ws.rest.contentType.WsRestRequestContentType$2.parseString(WsRestRequestContentType.java:112) 
at edu.internet2.middleware.grouper.ws.rest.GrouperRestServlet.service(GrouperRestServlet.java:186) 
at javax.servlet.http.HttpServlet.service(HttpServlet.java:742) 
at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:231) 
at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) 
at org.apache.tomcat.websocket.server.WsFilter.doFilter(WsFilter.java:52) 
at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) 
at org.apache.catalina.core.ApplicationFilterChain.doFilter(ApplicationFilterChain.java:166) 
at edu.internet2.middleware.grouper.ws.GrouperServiceJ2ee.doFilter(GrouperServiceJ2ee.java:965) 
at org.apache.catalina.core.ApplicationFilterChain.internalDoFilter(ApplicationFilterChain.java:193) 
```

- The body is read here: https://github.com/Internet2/grouper/blob/master/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/rest/GrouperRestServlet.java#L136
- Then, the body is parsed here: https://github.com/Internet2/grouper/blob/master/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/rest/GrouperRestServlet.java#L185
- The request is the nulled: https://github.com/Internet2/grouper/blob/master/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/rest/contentType/WsRestRequestContentType.java#L107
- ...which will then cause an NPE here: https://github.com/Internet2/grouper/blob/master/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java#L111

Note the difference in 2.3:
https://github.com/Internet2/grouper/blob/GROUPER_2_3_BRANCH/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceJ2ee.java#L111

