### PR TITLE
GRP-2955 only bail on null ldapUser if needsTargetSystemUsers is true

### DIFF
--- a/grouper-misc/grouper-pspng/src/main/java/edu/internet2/middleware/grouper/pspng/LdapGroupProvisioner.java
+++ b/grouper-misc/grouper-pspng/src/main/java/edu/internet2/middleware/grouper/pspng/LdapGroupProvisioner.java
@@ -60,7 +60,7 @@ public class LdapGroupProvisioner extends LdapProvisioner<LdapGroupProvisionerCo
     // a) User object's group-listing attribute
     // or b) if the group-membership attribute is being fetched
 
-    if ( ldapUser == null ) {
+    if ( ldapUser == null && config.needsTargetSystemUsers() ) {
       LOG.warn("{}: Skipping adding membership to group {} because ldap user does not exist: {}",
           new Object[]{getDisplayName(), grouperGroupInfo, subject});
       return;
@@ -111,7 +111,7 @@ public class LdapGroupProvisioner extends LdapProvisioner<LdapGroupProvisionerCo
       return;
     }
 
-    if ( ldapUser == null ) {
+    if ( ldapUser == null && config.needsTargetSystemUsers() ) {
       LOG.warn("{}: Skipping removing membership from group {} because ldap user does not exist: {}",
           new Object[]{getDisplayName(), grouperGroupInfo, subject});
       return;


### PR DESCRIPTION
Fixes GRP-2955 so the ldap group provisioner in pspng can run correctly as a changelog consumer when users are not expected to be in the target ldap.  Otherwise, ldapUsers are never searched for (correctly), and these bail early and don't perform the action.

Behavior is undefined if a user sets needsTargetSystemUsers = FALSE and then they use the LDAP user in the JEXL anyways.  