### PR TITLE
Updates for DUO Security

### DIFF
--- a/grouper-misc/grouper-duo/pom.xml
+++ b/grouper-misc/grouper-duo/pom.xml
@@ -33,24 +33,11 @@
     <artifactId>grouper-duo</artifactId>
     <packaging>jar</packaging>
 
-     <repositories>
-         <repository>
-             <id>unicomiam</id>
-             <url>https://dl.bintray.com/uniconiam/maven/</url>
-         </repository>     
-    </repositories>
-
     <dependencies>
         <dependency>
             <groupId>com.duosecurity</groupId>
             <artifactId>duo-client</artifactId>
-            <version>0.2.1</version>
-            <exclusions>
-            	<exclusion>
-            		<groupId>com.squareup.okhttp</groupId>
-            		<artifactId>okhttp</artifactId>
-            	</exclusion>
-            </exclusions>
+            <version>0.3.0</version>
         </dependency>
         <dependency>
             <groupId>commons-lang</groupId>


### PR DESCRIPTION
remove uniconiam repo (this goes away tomorrow)
update duo version
remove exclusion (class from this dep is required)