### PR TITLE
Fixing high risk vulnerable dependencies

### DIFF
--- a/grouper-parent/pom.xml
+++ b/grouper-parent/pom.xml
@@ -99,12 +99,12 @@
         <cglib.version>3.3.0</cglib.version>
         <felix.version>7.0.3</felix.version>
         <jamon.version>2.81</jamon.version>
-        <xstream.version>1.4.9</xstream.version>
+        <xstream.version>1.4.19</xstream.version>
         <jsch.version>0.1.55</jsch.version>
         <commons.vfs2.version>2.4.1</commons.vfs2.version>
         <commons.jexl.version>2.1.1</commons.jexl.version>
         <commons.jexl3.version>3.0</commons.jexl3.version>
-        <commons.beanutils.version>1.9.3</commons.beanutils.version>
+        <commons.beanutils.version>1.9.4</commons.beanutils.version>
         <commons.cli.version>1.4</commons.cli.version>
         <commons.codec.version>1.11</commons.codec.version>
         <commons.betwixt.version>0.8</commons.betwixt.version>
@@ -179,8 +179,8 @@
         <httpmime>4.5.13</httpmime>
         <jackson.annotations>2.9.8</jackson.annotations>
         <jackson.core>2.9.8</jackson.core>
-        <jackson.databind>2.9.8</jackson.databind>        
-        <jsoup.version>1.12.1</jsoup.version>        
+        <jackson.databind>2.9.10.8</jackson.databind>        
+        <jsoup.version>1.14.2</jsoup.version>        
         <java-ipv6.version>0.17</java-ipv6.version>
         
         <!-- grouper-ui -->
@@ -190,7 +190,7 @@
         <struts.version>1.2.4</struts.version>
         <taglibs.standard.version>1.1.2</taglibs.standard.version>
         <jsp.version>2.3.2-b02</jsp.version>
-        <xercesimpl.version>2.11.0</xercesimpl.version>
+        <xercesimpl.version>2.12.0</xercesimpl.version>
         <okhttp.version>3.14.7</okhttp.version>
         <nimbus.oauth2.oidc.sdk>8.22</nimbus.oauth2.oidc.sdk>
     </properties>


### PR DESCRIPTION
Trivy is a dependency scanner that can check application dependencies for vulnerabilities. The current Grouper container has a bunch... which looks like dependabot has also flagged. This PR fixes as many (obvious) libraries changes that I could match up. I've not tested the application build/tests with this PR.

The scan can be reproduced with:

```sh
docker run -v /var/run/docker.sock:/var/run/docker.sock ghcr.io/aquasecurity/trivy:latest image --security-checks vuln --vuln-type library --timeout 10m --severity HIGH i2incommon/grouper:2.6.9
```

```
Java (jar)
==========
Total: 73 (HIGH: 73)

┌─────────────────────────────────────────────────────────┬────────────────┬──────────┬───────────────────┬────────────────────────────────────┬──────────────────────────────────────────────────────────────┐
│                         Library                         │ Vulnerability  │ Severity │ Installed Version │           Fixed Version            │                            Title                             │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2019-12086 │ HIGH     │ 2.9.6             │ 2.7.9.6, 2.8.11.4, 2.9.9           │ jackson-databind: polymorphic typing issue allows attacker   │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ to read arbitrary local files on...                          │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2019-12086                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2019-14439 │          │                   │ 2.7.9.6, 2.8.11.4, 2.9.9.2         │ jackson-databind: Polymorphic typing issue related to        │
│                                                         │                │          │                   │                                    │ logback/JNDI                                                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2019-14439                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-10672 │          │                   │ 2.9.10.4                           │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing which could result...       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-10672                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-10673 │          │                   │ 2.6.7.4, 2.9.10.4                  │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing which could result...       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-10673                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-10968 │          │                   │ 2.9.10.4                           │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ org.aoju.bus.proxy.provider.*.RmiProvider                    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-10968                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-10969 │          │                   │ 2.7.9.7, 2.8.11.6, 2.9.10.4        │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ javax.swing.JEditorPane                                      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-10969                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-11111 │          │                   │ 2.9.10.4                           │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ org.apache.activemq.jms.pool.XaPooledConnectionFactory       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11111                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-11112 │          │                   │                                    │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ org.apache.commons.proxy.provider.remoting.RmiProvider       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11112                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-11113 │          │                   │                                    │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ org.apache.openjpa.ee.WASRegistryManagedRuntime              │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11113                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-11619 │          │                   │                                    │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ org.springframework:spring-aop                               │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11619                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-11620 │          │                   │                                    │ jackson-databind: Serialization gadgets in                   │
│                                                         │                │          │                   │                                    │ commons-jelly:commons-jelly                                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11620                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-14060 │          │                   │ 2.9.10.5                           │ jackson-databind: serialization in                           │
│                                                         │                │          │                   │                                    │ oadd.org.apache.xalan.lib.sql.JNDIConnectionPool             │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-14060                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-14061 │ HIGH     │ 2.9.6             │ 2.9.10.5                           │ jackson-databind: serialization in weblogic/oracle-aqjms     │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-14061                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-14062 │ HIGH     │ 2.9.6             │ 2.9.10.5                           │ jackson-databind: serialization in                           │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ com.sun.org.apache.xalan.internal.lib.sql.JNDIConnectionPool │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-14062                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-14195 │          │                   │                                    │ jackson-databind: serialization in                           │
│                                                         │                │          │                   │                                    │ org.jsecurity.realm.jndi.JndiRealmFactory                    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-14195                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-24616 │ HIGH     │ 2.9.6             │ 2.9.10.6                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ br.com.anteros.dbcp.AnterosDBCPDataSource...                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-24616                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-24750 │ HIGH     │ 2.9.6             │ 2.9.10.6                           │ jackson-databind: Serialization gadgets in                   │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ com.pastdev.httpcomponents.configuration.JndiConfiguration   │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-24750                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-25649 │          │                   │ 2.6.7.4, 2.9.10.7, 2.10.5.1        │ jackson-databind: FasterXML DOMDeserializer insecure entity  │
│                                                         │                │          │                   │                                    │ expansion is vulnerable to XML external entity...            │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-25649                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-35490 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.commons.dbcp2.datasources.PerUserPoolDataSource.- │
│                                                         │                │          │                   │                                    │ ..                                                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-35490                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-35491 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.commons.dbcp2.datasources.SharedPoolDataSource... │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-35491                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-35728 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnecti- │
│                                                         │                │          │                   │                                    │ onPool...                                                    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-35728                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36179 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS.- │
│                                                         │                │          │                   │                                    │ ..                                                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36179                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-36180 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS...    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36180                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36181 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS... │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36181                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-36182 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS.- │
│                                                         │                │          │                   │                                    │ ..                                                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36182                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-36183 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool...    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36183                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-36184 │ HIGH     │ 2.9.6             │ 2.9.10.8                           │ jackson-databind: mishandles the interaction between         │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSou- │
│                                                         │                │          │                   │                                    │ rce...                                                       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36184                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36185 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSour- │
│                                                         │                │          │                   │                                    │ ce...                                                        │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36185                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36186 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSour- │
│                                                         │                │          │                   │                                    │ ce...                                                        │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36186                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36187 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSourc- │
│                                                         │                │          │                   │                                    │ e...                                                         │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36187                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36188 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnecti- │
│                                                         │                │          │                   │                                    │ onSource...                                                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36188                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-36189 │          │                   │                                    │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to                 │
│                                                         │                │          │                   │                                    │ com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManage- │
│                                                         │                │          │                   │                                    │ rConnectionSource...                                         │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36189                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.fasterxml.jackson.core:jackson-databind             │ CVE-2020-36518 │ HIGH     │ 2.9.6             │ 2.12.6.1, 2.13.2.1                 │ jackson-databind: denial of service via a large depth of     │
│ (jackson-databind-2.9.6.jar)                            │                │          │                   │                                    │ nested objects                                               │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-36518                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-20190 │          │                   │ 2.9.10.7                           │ jackson-databind: mishandles the interaction between         │
│                                                         │                │          │                   │                                    │ serialization gadgets and typing, related to javax.swing...  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-20190                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.google.code.gson:gson (gson-2.8.2.jar)              │ CVE-2022-25647 │          │ 2.8.2             │ 2.8.9                              │ com.google.code.gson-gson: Deserialization of Untrusted Data │
│                                                         │                │          │                   │                                    │ in com.google.code.gson-gson                                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2022-25647                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.google.oauth-client:google-oauth-client             │ CVE-2021-22573 │ HIGH     │ 1.23.0            │ 1.33.3                             │ google-oauth-client: Token signature not verified            │
│ (google-oauth-client-1.23.0.jar)                        │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-22573                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2017-7957  │          │ 1.4.9             │ 1.4.10                             │ XStream: DoS when unmarshalling void type                    │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2017-7957                    │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2020-26217 │ HIGH     │ 1.4.9             │ 1.4.14                             │ XStream: remote code execution due to insecure XML           │
│                                                         │                │          │                   │                                    │ deserialization when relying on...                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-26217                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2020-26258 │          │                   │ 1.4.15                             │ XStream: Server-Side Forgery Request vulnerability can be    │
│                                                         │                │          │                   │                                    │ activated when unmarshalling                                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-26258                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-21341 │          │                   │ 1.4.16                             │ XStream: allow a remote attacker to cause DoS only by        │
│                                                         │                │          │                   │                                    │ manipulating the...                                          │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-21341                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-21343 │          │                   │                                    │ XStream: arbitrary file deletion on the local host via       │
│                                                         │                │          │                   │                                    │ crafted input stream...                                      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-21343                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2021-21348 │ HIGH     │ 1.4.9             │ 1.4.16                             │ XStream: ReDoS vulnerability                                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-21348                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2021-21349 │ HIGH     │ 1.4.9             │ 1.4.16                             │ XStream: SSRF can be activated unmarshalling with XStream to │
│                                                         │                │          │                   │                                    │ access data streams...                                       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-21349                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-29505 │          │                   │ 1.4.17                             │ XStream: remote command execution attack by manipulating the │
│                                                         │                │          │                   │                                    │ processed input stream                                       │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-29505                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39139 │          │                   │ 1.4.18                             │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of Xalan xsltc.trax.TemplatesImpl                            │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39139                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39141 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.xml.internal.ws.client.sei.*                      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39141                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39144 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of sun.tracing.*                                             │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39144                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39145 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.jndi.ldap.LdapBindingEnumeration                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39145                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39146 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of javax.swing.UIDefaults$ProxyLazyValue                     │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39146                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39147 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.jndi.ldap.LdapSearchEnumeration                   │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39147                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39148 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.jndi.toolkit.dir.ContextEnumerator                │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39148                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39149 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.corba.*                                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39149                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39150 │          │                   │                                    │ xstream: Server-side request forgery (SSRF) via unsafe       │
│                                                         │                │          │                   │                                    │ deserialization of com.sun.xml.internal.ws.client.sei.*      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39150                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39151 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of com.sun.jndi.ldap.LdapBindingEnumeration                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39151                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2021-39152 │ HIGH     │ 1.4.9             │ 1.4.18                             │ xstream: Server-side request forgery (SSRF) via unsafe       │
│                                                         │                │          │                   │                                    │ deserialization of                                           │
│                                                         │                │          │                   │                                    │ jdk.nashorn.internal.runtime.Source$URLData                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39152                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ com.thoughtworks.xstream:xstream (xstream-1.4.9.jar)    │ CVE-2021-39153 │ HIGH     │ 1.4.9             │ 1.4.18                             │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of Xalan xsltc.trax.TemplatesImpl                            │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39153                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-39154 │          │                   │                                    │ xstream: Arbitrary code execution via unsafe deserialization │
│                                                         │                │          │                   │                                    │ of javax.swing.UIDefaults$ProxyLazyValue                     │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-39154                   │
│                                                         ├────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-43859 │          │                   │ 1.4.19                             │ xstream: Injecting highly recursive collections or maps can  │
│                                                         │                │          │                   │                                    │ cause a DoS                                                  │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-43859                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ commons-beanutils:commons-beanutils                     │ CVE-2019-10086 │          │ 1.9.3             │ 1.9.4                              │ apache-commons-beanutils: does not suppresses the class      │
│ (commons-beanutils-1.9.3.jar)                           │                │          │                   │                                    │ property in PropertyUtilsBean by default                     │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2019-10086                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ commons-fileupload:commons-fileupload                   │ CVE-2016-3092  │          │ 1.3.1             │ 1.3.2                              │ tomcat: Usage of vulnerable FileUpload package can result in │
│ (commons-fileupload-1.3.1.jar)                          │                │          │                   │                                    │ denial of service...                                         │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2016-3092                    │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-codec (netty-codec-4.1.34.Final.jar)     │ CVE-2021-37136 │          │ 4.1.34.Final      │ 4.1.68.Final                       │ netty-codec: Bzip2Decoder doesn't allow setting size         │
│                                                         │                │          │                   │                                    │ restrictions for decompressed data                           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-37136                   │
│                                                         ├────────────────┤          │                   │                                    ├──────────────────────────────────────────────────────────────┤
│                                                         │ CVE-2021-37137 │          │                   │                                    │ netty-codec: SnappyFrameDecoder doesn't restrict chunk       │
│                                                         │                │          │                   │                                    │ length and may buffer skippable chunks in...                 │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-37137                   │
├─────────────────────────────────────────────────────────┼────────────────┤          │                   ├────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ io.netty:netty-handler (netty-handler-4.1.34.Final.jar) │ CVE-2020-11612 │          │                   │ 4.1.46                             │ netty: compression/decompression codecs don't enforce limits │
│                                                         │                │          │                   │                                    │ on buffer allocation sizes                                   │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-11612                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.commons:commons-collections4                 │ CVE-2015-6420  │ HIGH     │ 4.0               │ 4.1                                │ Insecure Deserialization in Apache Commons Collection        │
│ (commons-collections4-4.0.jar)                          │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2015-6420                    │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.myfaces.core:myfaces-impl                    │ CVE-2021-26296 │ HIGH     │ 2.2.12            │ 2.2.14, 2.3.8                      │ myfaces: Cross-site request forgery vulnerability in Apache  │
│ (myfaces-impl-2.2.12.jar)                               │                │          │                   │                                    │ MyFaces                                                      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-26296                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.apache.santuario:xmlsec (xmlsec-1.4.5.jar)          │ CVE-2021-40690 │          │ 1.4.5             │ 2.1.7, 2.2.3                       │ xml-security: XPath Transform abuse allows for information   │
│                                                         │                │          │                   │                                    │ disclosure                                                   │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-40690                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.hibernate:hibernate-core                            │ CVE-2020-25638 │          │ 5.0.12.Final      │ 5.3.20.Final, 5.4.24.Final         │ hibernate-core: SQL injection vulnerability when both        │
│ (hibernate-core-5.0.12.Final.jar)                       │                │          │                   │                                    │ hibernate.use_sql_comments and JPQL String literals are...   │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-25638                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.jdom:jdom (jdom-1.1.jar)                            │ CVE-2021-33813 │          │ 1.1               │ 2.0.6.1                            │ jdom: XXE allows attackers to cause a DoS via a crafted      │
│                                                         │                │          │                   │                                    │ HTTP...                                                      │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-33813                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.jsoup:jsoup (jsoup-1.12.1.jar)                      │ CVE-2021-37714 │          │ 1.12.1            │ 1.14.2                             │ jsoup: Crafted input may cause the jsoup HTML and XML parser │
│                                                         │                │          │                   │                                    │ to...                                                        │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-37714                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.mortbay.jetty:jetty (jetty-6.1.26.jar)              │ CVE-2020-27216 │ HIGH     │ 6.1.26            │ 9.4.33, 10.0.0.beta3, 11.0.0.beta3 │ jetty: local temporary directory hijacking vulnerability     │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2020-27216                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.owasp:csrfguard (csrfguard-3.1.0.jar)               │ CVE-2021-28490 │          │ 3.1.0             │                                    │ Cross-Site Request Forgery in OWASP CSRFGuard                │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2021-28490                   │
├─────────────────────────────────────────────────────────┼────────────────┤          ├───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ org.yaml:snakeyaml (jackson-dataformat-yaml-2.4.2.jar)  │ CVE-2017-18640 │          │ 1.12              │ 1.26                               │ snakeyaml: Billion laughs attack via alias feature           │
│                                                         │                │          │                   │                                    │ https://avd.aquasec.com/nvd/cve-2017-18640                   │
├─────────────────────────────────────────────────────────┼────────────────┼──────────┼───────────────────┼────────────────────────────────────┼──────────────────────────────────────────────────────────────┤
│ xerces:xercesImpl (xercesImpl-2.11.0.jar)               │ CVE-2012-0881  │ HIGH     │ 2.11.0            │ 2.12.0                             │ xml: xerces-j2 hash table collisions CPU usage DoS           │
│                                                         │                │          │  …