### PR TITLE
GRP-4800: WS GshTemplateExec returns success even though GshTemplateExecOutput.isSuccess=false

### DIFF
--- a/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceLogic.java
+++ b/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceLogic.java
@@ -11058,7 +11058,8 @@ public class GrouperServiceLogic {
       }
       
       GshTemplateExecOutput output = exec.execute();
-      
+
+      wsGshTemplateExecResult.setGshExitCode(output.getGrouperGroovyResult().getResultCode());
       if (output.getException() != null) {
         wsGshTemplateExecResult.assignResultCodeException(output.getException(), output.getExceptionStack(), clientVersion);
       } else {
@@ -11091,12 +11092,13 @@ public class GrouperServiceLogic {
         
         if (wsGshValidationLines.length > 0) {
           wsGshTemplateExecResult.assignResultCode(WsGshTemplateExecResultCode.INVALID, clientVersion);
+        } else if (!output.isSuccess() && GrouperWsConfig.retrieveConfig().propertyValueBoolean("ws.gshTemplate.ResultConsiderExecStatus", false)) {
+          wsGshTemplateExecResult.assignResultCode(WsGshTemplateExecResultCode.ERROR, clientVersion);
+          wsGshTemplateExecResult.getResultMetadata().appendResultMessage("Error for: " + theSummary);
         } else {
           wsGshTemplateExecResult.assignResultCode(WsGshTemplateExecResultCode.SUCCESS, clientVersion);
           wsGshTemplateExecResult.getResultMetadata().appendResultMessage("Success for: " + theSummary);
         }
-        
-        
       }
       
       

--- a/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceLogic.java
+++ b/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/GrouperServiceLogic.java
@@ -11092,7 +11092,7 @@ public class GrouperServiceLogic {
         
         if (wsGshValidationLines.length > 0) {
           wsGshTemplateExecResult.assignResultCode(WsGshTemplateExecResultCode.INVALID, clientVersion);
-        } else if (!output.isSuccess() && GrouperWsConfig.retrieveConfig().propertyValueBoolean("ws.gshTemplate.ResultConsiderExecStatus", false)) {
+        } else if (!output.isSuccess() && GrouperWsConfig.retrieveConfig().propertyValueBoolean("ws.gshTemplate.ResultConsiderExecStatus", true)) {
           wsGshTemplateExecResult.assignResultCode(WsGshTemplateExecResultCode.ERROR, clientVersion);
           wsGshTemplateExecResult.getResultMetadata().appendResultMessage("Error for: " + theSummary);
         } else {

--- a/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/coresoap/WsGshTemplateExecResult.java
+++ b/grouper-ws/grouper-ws/src/grouper-ws/edu/internet2/middleware/grouper/ws/coresoap/WsGshTemplateExecResult.java
@@ -18,6 +18,9 @@ public class WsGshTemplateExecResult implements WsResponseBean, ResultMetadataHo
     SUCCESS(200),
 
     /** exception was thrown while running gsh template (http status code 500) (success: F) */
+    ERROR(500),
+
+    /** exception was thrown while running gsh template (http status code 500) (success: F) */
     EXCEPTION(500),
 
     /** invalid input (e.g. if everything blank) (http status code 400) (success: F) */
@@ -73,9 +76,11 @@ public class WsGshTemplateExecResult implements WsResponseBean, ResultMetadataHo
   private WsGshValidationLine[] gshValidationLines;
   
   private WsGshOutputLine[] gshOutputLines;
-  
+
   private String gshScriptOutput;
-  
+
+  private Integer gshExitCode;
+
   
   public Boolean getTransaction() {
     return transaction;
@@ -154,5 +159,22 @@ public class WsGshTemplateExecResult implements WsResponseBean, ResultMetadataHo
   public void assignResultCode(WsGshTemplateExecResultCode wsGshTemplateExecResultCode, GrouperVersion clientVersion) {
     this.getResultMetadata().assignResultCode(wsGshTemplateExecResultCode, clientVersion);
   }
-  
+
+  /**
+   * Exit code returned by the gsh script (non-zero generally indicates an error)
+   * @return
+   */
+  public Integer getGshExitCode() {
+    return gshExitCode;
+  }
+
+  /**
+   * Exit code returned by the gsh script (non-zero generally indicates an error)
+   * @param gshExitCode
+   * @return
+   */
+  public WsGshTemplateExecResult setGshExitCode(Integer gshExitCode) {
+    this.gshExitCode = gshExitCode;
+    return this;
+  }
 }

--- a/grouper/conf/grouper-ws-ng.base.properties
+++ b/grouper/conf/grouper-ws-ng.base.properties
@@ -179,11 +179,11 @@ jsonConverter =
 # {valueType: "integer", required: true}
 ws.longRunningRequestLogMillis = 30000
 
-# Retain existing behavior up to v4.4.0, in which WsRestGshTemplateExecRequest returned success even though the GSH
-# script had a non-success status (by explicitly setting status, a non-zero GrouperUtil.gshReturn(int code), or adding
-# output lines of type error)
+# If set to false, retain existing behavior up to v4.4.0, in which WsRestGshTemplateExecRequest returned success even
+# though the GSH script had a non-success status (by explicitly setting status, a non-zero GrouperUtil.gshReturn(int code),
+# or adding output lines of type error)
 # {valueType: "boolean", required: true}
-ws.gshTemplate.ResultConsiderExecStatus = false
+ws.gshTemplate.ResultConsiderExecStatus = true
 
 #################################################################
 ## KERBEROS settings, only needed if doing kerberos simple auth

--- a/grouper/conf/grouper-ws-ng.base.properties
+++ b/grouper/conf/grouper-ws-ng.base.properties
@@ -179,6 +179,12 @@ jsonConverter =
 # {valueType: "integer", required: true}
 ws.longRunningRequestLogMillis = 30000
 
+# Retain existing behavior up to v4.4.0, in which WsRestGshTemplateExecRequest returned success even though the GSH
+# script had a non-success status (by explicitly setting status, a non-zero GrouperUtil.gshReturn(int code), or adding
+# output lines of type error)
+# {valueType: "boolean", required: true}
+ws.gshTemplate.ResultConsiderExecStatus = false
+
 #################################################################
 ## KERBEROS settings, only needed if doing kerberos simple auth
 #################################################################


### PR DESCRIPTION
Adds a new WS config property: `ws.gshTemplate.ResultConsiderExecStatus = false`. The default is to retain the existing behavior, so shouldn't have any surprising effects.

The WsGshTemplateExecResult does include a new property for gshExitCode, which can be set by the script using `GrouperUtil.gshReturn(int returnCode)`