### PR TITLE
Add assignContentType to Gc classes

### DIFF
--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAddMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAddMember.java
@@ -122,7 +122,7 @@ public class GcAddMember {
   
   /** group uuid to add member to */
   private String groupUuid;
-  
+
   /** date this membership will be disabled, yyyy/MM/dd HH:mm:ss.SSS */
   private Timestamp disabledTime;
   
@@ -144,7 +144,7 @@ public class GcAddMember {
   public void assignEnabledTime(Timestamp theEnabledTime) {
     this.enabledTime = theEnabledTime;
   }
-  
+
   
   /**
    * set the group name
@@ -371,6 +371,19 @@ public class GcAddMember {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAddMember assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -433,7 +446,9 @@ public class GcAddMember {
       addMember.setEnabledTime(GrouperClientUtils.dateToString(this.enabledTime));
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefActions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefActions.java
@@ -106,6 +106,19 @@ public class GcAssignAttributeDefActions {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignAttributeDefActions assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** Attribute Definition to be modified **/
   private WsAttributeDefLookup wsAttributeDefLookup;
 
@@ -254,6 +267,8 @@ public class GcAssignAttributeDefActions {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefNameInheritance.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefNameInheritance.java
@@ -127,6 +127,19 @@ public class GcAssignAttributeDefNameInheritance {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignAttributeDefNameInheritance assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   //--attributeDefNameName=attributeDefNameName0 
   //--relatedAttributeDefNameNames=relatedName0,relatedName1 
   //--assign=T|F [--replaceAllExisting=T|F] 
@@ -293,6 +306,8 @@ public class GcAssignAttributeDefNameInheritance {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributes.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributes.java
@@ -203,7 +203,7 @@ public class GcAssignAttributes {
     this.actions.add(action);
     return this;
   }
-  
+
   /**
    * assign client version
    * @param theClientVersion
@@ -211,6 +211,19 @@ public class GcAssignAttributes {
    */
   public GcAssignAttributes assignClientVersion(String theClientVersion) {
     this.clientVersion = theClientVersion;
+    return this;
+  }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignAttributes assignContentType(String theContentType) {
+    this.contentType = theContentType;
     return this;
   }
   
@@ -612,7 +625,9 @@ public class GcAssignAttributes {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributesBatch.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributesBatch.java
@@ -151,7 +151,20 @@ public class GcAssignAttributesBatch {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignAttributesBatch assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
 
@@ -277,7 +290,9 @@ public class GcAssignAttributesBatch {
       assignAttributesBatch.setTxType(this.txType == null ? null : this.txType.name());
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivileges.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivileges.java
@@ -312,6 +312,19 @@ public class GcAssignGrouperPrivileges {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignGrouperPrivileges assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** if we should replace all existing */
   private Boolean replaceAllExisting = null;
@@ -384,7 +397,9 @@ public class GcAssignGrouperPrivileges {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivilegesLite.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivilegesLite.java
@@ -126,7 +126,7 @@ public class GcAssignGrouperPrivilegesLite {
     this.allowed = isAllowed;
     return this;
   }
-  
+
   /** group name to assign privileges */
   private String groupName;
   
@@ -292,6 +292,19 @@ public class GcAssignGrouperPrivilegesLite {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignGrouperPrivilegesLite assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -354,7 +367,9 @@ public class GcAssignGrouperPrivilegesLite {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignPermissions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignPermissions.java
@@ -185,7 +185,20 @@ public class GcAssignPermissions {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAssignPermissions assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** group names to query */
   private Set<String> roleNames = new LinkedHashSet<String>();
   
@@ -489,6 +502,8 @@ public class GcAssignPermissions {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefDelete.java
@@ -197,6 +197,19 @@ public class GcAttributeDefDelete {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAttributeDefDelete assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
    * exception will be thrown
@@ -226,6 +239,8 @@ public class GcAttributeDefDelete {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameDelete.java
@@ -198,6 +198,19 @@ public class GcAttributeDefNameDelete {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAttributeDefNameDelete assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -226,6 +239,8 @@ public class GcAttributeDefNameDelete {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameSave.java
@@ -128,6 +128,19 @@ public class GcAttributeDefNameSave {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAttributeDefNameSave assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** attributeDefNames to save */
   private List<WsAttributeDefNameToSave> attributeDefNamesToSave = new ArrayList<WsAttributeDefNameToSave>();
@@ -219,6 +232,8 @@ public class GcAttributeDefNameSave {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefSave.java
@@ -126,6 +126,19 @@ public class GcAttributeDefSave {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcAttributeDefSave assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** attributeDefs to save */
   private List<WsAttributeDefToSave> attributeDefsToSave = new ArrayList<WsAttributeDefToSave>();
 
@@ -220,6 +233,8 @@ public class GcAttributeDefSave {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcDeleteMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcDeleteMember.java
@@ -128,7 +128,19 @@ public class GcDeleteMember {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcDeleteMember assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** group name to delete member from */
   private String groupName;
@@ -356,7 +368,9 @@ public class GcDeleteMember {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectDelete.java
@@ -207,6 +207,19 @@ public class GcExternalSubjectDelete {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcExternalSubjectDelete assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -235,7 +248,9 @@ public class GcExternalSubjectDelete {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectSave.java
@@ -126,6 +126,19 @@ public class GcExternalSubjectSave {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcExternalSubjectSave assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** external subjects to save */
   private List<WsExternalSubjectToSave> externalSubjectsToSave = new ArrayList<WsExternalSubjectToSave>();
@@ -217,7 +230,9 @@ public class GcExternalSubjectSave {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefNames.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefNames.java
@@ -243,7 +243,19 @@ public class GcFindAttributeDefNames {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcFindAttributeDefNames assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
@@ -520,7 +532,9 @@ public class GcFindAttributeDefNames {
       findAttributeDefNames.setPageLastCursorFieldType(this.pageLastCursorFieldType);
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefs.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefs.java
@@ -158,6 +158,19 @@ public class GcFindAttributeDefs {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcFindAttributeDefs assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
 
@@ -420,6 +433,8 @@ public class GcFindAttributeDefs {
       findAttributeDefs.setPageLastCursorFieldType(this.pageLastCursorFieldType);
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindExternalSubjects.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindExternalSubjects.java
@@ -127,7 +127,19 @@ public class GcFindExternalSubjects {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcFindExternalSubjects assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
@@ -205,7 +217,9 @@ public class GcFindExternalSubjects {
 
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindGroups.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindGroups.java
@@ -141,7 +141,19 @@ public class GcFindGroups {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcFindGroups assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
@@ -252,10 +264,11 @@ public class GcFindGroups {
         groupLookups.add(new WsGroupLookup(null, null, groupIdIndex.toString()));
       }
       findGroups.setWsGroupLookups(GrouperClientUtils.toArray(groupLookups, WsGroupLookup.class));
-
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindStems.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindStems.java
@@ -141,7 +141,20 @@ public class GcFindStems {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcFindStems assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
@@ -235,7 +248,9 @@ public class GcFindStems {
       findStems.setWsStemLookups(GrouperClientUtils.toArray(stemLookups, WsStemLookup.class));
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignActions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignActions.java
@@ -62,6 +62,19 @@ public class GcGetAttributeAssignActions {
     return this;
   }
 
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetAttributeAssignActions assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
 
@@ -170,6 +183,8 @@ public class GcGetAttributeAssignActions {
       }
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
+
+      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignments.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignments.java
@@ -391,6 +391,19 @@ public class GcGetAttributeAssignments {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetAttributeAssignments assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** group names to query */
   private Set<String> ownerGroupNames = new LinkedHashSet<String>();
@@ -823,7 +836,9 @@ public class GcGetAttributeAssignments {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAuditEntries.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAuditEntries.java
@@ -131,7 +131,19 @@ public class GcGetAuditEntries {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetAuditEntries assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** params */
   private List<WsParam> params = new ArrayList<WsParam>();
@@ -413,7 +425,9 @@ public class GcGetAuditEntries {
       getAuditEntries.setPageLastCursorFieldType(this.pageLastCursorFieldType);
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGrouperPrivilegesLite.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGrouperPrivilegesLite.java
@@ -276,6 +276,19 @@ public class GcGetGrouperPrivilegesLite {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetGrouperPrivilegesLite assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -333,7 +346,9 @@ public class GcGetGrouperPrivilegesLite {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGroups.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGroups.java
@@ -132,7 +132,19 @@ public class GcGetGroups {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetGroups assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
 
   /** subject lookups */
   private List<WsSubjectLookup> subjectLookups = new ArrayList<WsSubjectLookup>();
@@ -513,7 +525,9 @@ public class GcGetGroups {
       getGroups.setPageLastCursorFieldType(this.pageLastCursorFieldType);
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMembers.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMembers.java
@@ -247,6 +247,19 @@ public class GcGetMembers {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetMembers assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** group names to query */
   private Set<String> groupNames = new LinkedHashSet<String>();
@@ -901,7 +914,9 @@ public class GcGetMembers {
       getMembers.setPageLastCursorFieldType(this.pageLastCursorFieldType);
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMemberships.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMemberships.java
@@ -144,6 +144,19 @@ public class GcGetMemberships {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetMemberships assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * assign stem to limit memberships
@@ -926,10 +939,10 @@ public class GcGetMemberships {
       getMemberships.setPageLastCursorFieldForMember(this.pageLastCursorFieldForMember);
       getMemberships.setPageLastCursorFieldTypeForMember(this.pageLastCursorFieldTypeForMember);
       
-      
-      
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetPermissionAssignments.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetPermissionAssignments.java
@@ -301,7 +301,20 @@ public class GcGetPermissionAssignments {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetPermissionAssignments assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /** group names to query */
   private Set<String> roleNames = new LinkedHashSet<String>();
   
@@ -635,7 +648,9 @@ public class GcGetPermissionAssignments {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetSubjects.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetSubjects.java
@@ -154,6 +154,19 @@ public class GcGetSubjects {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGetSubjects assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** if filtering by group, this is the group lookup */
   private WsGroupLookup wsGroupLookup;
@@ -347,7 +360,9 @@ public class GcGetSubjects {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupDelete.java
@@ -211,6 +211,19 @@ public class GcGroupDelete {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGroupDelete assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupSave.java
@@ -128,6 +128,19 @@ public class GcGroupSave {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcGroupSave assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** groups to save */
   private List<WsGroupToSave> groupsToSave = new ArrayList<WsGroupToSave>();
@@ -235,7 +248,9 @@ public class GcGroupSave {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcHasMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcHasMember.java
@@ -129,6 +129,19 @@ public class GcHasMember {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcHasMember assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** group name to add member to */
   private String groupName;
@@ -426,7 +439,9 @@ public class GcHasMember {
       hasMember.setPointInTimeTo(GrouperClientUtils.dateToString(this.pointInTimeTo));
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMemberChangeSubject.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMemberChangeSubject.java
@@ -255,6 +255,19 @@ public class GcMemberChangeSubject {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcMemberChangeSubject assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -297,7 +310,9 @@ public class GcMemberChangeSubject {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageAcknowledge.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageAcknowledge.java
@@ -242,7 +242,20 @@ public class GcMessageAcknowledge {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcMessageAcknowledge assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
    * exception will be thrown
@@ -271,7 +284,9 @@ public class GcMessageAcknowledge {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageReceive.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageReceive.java
@@ -239,6 +239,19 @@ public class GcMessageReceive {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcMessageReceive assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
@@ -268,7 +281,9 @@ public class GcMessageReceive {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageSend.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageSend.java
@@ -251,7 +251,20 @@ public class GcMessageSend {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcMessageSend assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
    * exception will be thrown
@@ -280,7 +293,9 @@ public class GcMessageSend {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemDelete.java
@@ -209,7 +209,20 @@ public class GcStemDelete {
     this.clientVersion = theClientVersion;
     return this;
   }
-  
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcStemDelete assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
+
   /**
    * execute the call and return the results.  If there is a problem calling the service, an
    * exception will be thrown
@@ -237,7 +250,9 @@ public class GcStemDelete {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemSave.java
@@ -127,6 +127,19 @@ public class GcStemSave {
     this.clientVersion = theClientVersion;
     return this;
   }
+
+  /** content type for post request */
+  private String contentType;
+
+  /**
+   * content type for post request
+   * @param theContentType
+   * @return this for chaining
+   */
+  public GcStemSave assignContentType(String theContentType) {
+    this.contentType = theContentType;
+    return this;
+  }
   
   /** stems to save */
   private List<WsStemToSave> stemsToSave = new ArrayList<WsStemToSave>();
@@ -219,7 +232,9 @@ public class GcStemSave {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
+      grouperClientWs.assignContentType(this.contentType);
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);


### PR DESCRIPTION
Hello! I'm a student from the University of Hawaii working on a project that utilizes Grouper and GrouperClient. We are in the process of updating our codebase from Java 8 to Java 17 and have run into this unique situation where our Grouper is still on version 2.2 while our project needs to use a version of Grouper Client that supports Java 17. The main issue is that the POST requests made by GrouperClientWs sets the default content type of the request header to `application/json`, which is unrecognized by the Grouper server, as it only accepts `text/x-json`. So this PR adds a method to assign the content type to all Gc classes that use the GrouperClientWs class to make the POST request. The only Gc class left unchanged is `GcLdapSearchAttribute` since it doesn't use the GrouperClientWs class.