### PR TITLE
GrouperClient: Fix assignContentType

### DIFF
--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/GrouperClient.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/GrouperClient.java
@@ -1028,15 +1028,10 @@ public class GrouperClient {
           grouperClientWs.assignWsPass(new Crypto(encryptKey).decrypt(GrouperClientUtils.readFileIntoString(new File(wsPassFileEncrypted))));
         }
       }
-
-
-      if (GrouperClientUtils.isNotBlank(contentType)) {
-        grouperClientWs.assignContentType(contentType);
-      }
       
       try {
         //assume the url suffix is already escaped...
-        String results = (String)grouperClientWs.executeService(urlSuffix, fileContents, labelForLog, clientVersion, readOnly);
+        String results = (String)grouperClientWs.executeService(urlSuffix, fileContents, labelForLog, clientVersion, contentType, readOnly);
 
         if (indentOutput) {
           results = GrouperClientUtils.indent(results, false);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAddMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAddMember.java
@@ -447,8 +447,6 @@ public class GcAddMember {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -459,7 +457,8 @@ public class GcAddMember {
       //    + GrouperClientUtils.escapeUrlEncode(this.groupName) + "/members";
       String urlSuffix = "groups";
       wsAddMemberResults = (WsAddMemberResults)
-        grouperClientWs.executeService(urlSuffix, addMember, "addMember", this.clientVersion, false);
+          grouperClientWs.executeService(urlSuffix, addMember, "addMember",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAddMemberResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAddMemberResults, wsAddMemberResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefActions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefActions.java
@@ -268,8 +268,6 @@ public class GcAssignAttributeDefActions {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -278,7 +276,7 @@ public class GcAssignAttributeDefActions {
       wsAttributeDefAssignActionResults = (WsAttributeDefAssignActionResults)
           grouperClientWs.executeService("attributeDefActions",
               assignAttributeDefActionRequest, "assignActionsToAttributeDef",
-              this.clientVersion, false);
+              this.clientVersion, this.contentType, false);
 
       String attributeDefNameSaveResultMessage = "";
 

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefNameInheritance.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributeDefNameInheritance.java
@@ -307,15 +307,15 @@ public class GcAssignAttributeDefNameInheritance {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignAttributeDefNameInheritanceResults = (WsAssignAttributeDefNameInheritanceResults)
-        grouperClientWs.executeService("attributeDefNames", assignAttributeDefNameInheritance, "assignAttributeDefNameInheritance", this.clientVersion, false);
+          grouperClientWs.executeService("attributeDefNames",
+              assignAttributeDefNameInheritance, "assignAttributeDefNameInheritance",
+              this.clientVersion, this.contentType, false);
       
       String attributeDefNameSaveResultMessage = "";
       

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributes.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributes.java
@@ -626,15 +626,14 @@ public class GcAssignAttributes {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignAttributesResults = (WsAssignAttributesResults)
-        grouperClientWs.executeService("attributeAssignments", assignAttributes, "assignAttributes", this.clientVersion, false);
+          grouperClientWs.executeService("attributeAssignments", assignAttributes, "assignAttributes",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAssignAttributesResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAssignAttributesResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributesBatch.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignAttributesBatch.java
@@ -291,15 +291,15 @@ public class GcAssignAttributesBatch {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignAttributesBatchResults = (WsAssignAttributesBatchResults)
-        grouperClientWs.executeService("attributeAssignments", assignAttributesBatch, "assignAttributesBatch", this.clientVersion, false);
+          grouperClientWs.executeService("attributeAssignments",
+              assignAttributesBatch, "assignAttributesBatch",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAssignAttributesBatchResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAssignAttributesBatchResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivileges.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivileges.java
@@ -398,16 +398,15 @@ public class GcAssignGrouperPrivileges {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignGrouperPrivilegesResults = (WsAssignGrouperPrivilegesResults)
-        grouperClientWs.executeService("grouperPrivileges", wsAssignGrouperPrivileges, 
-            "assignGrouperPrivileges", this.clientVersion, false);
+          grouperClientWs.executeService("grouperPrivileges",
+              wsAssignGrouperPrivileges, "assignGrouperPrivileges",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAssignGrouperPrivilegesResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAssignGrouperPrivilegesResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivilegesLite.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignGrouperPrivilegesLite.java
@@ -368,16 +368,15 @@ public class GcAssignGrouperPrivilegesLite {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignGrouperPrivilegesLiteResult = (WsAssignGrouperPrivilegesLiteResult)
-        grouperClientWs.executeService("grouperPrivileges", wsAssignGrouperPrivilegesLite, 
-            "assignGrouperPrivilegesLite", this.clientVersion, false);
+          grouperClientWs.executeService("grouperPrivileges",
+              wsAssignGrouperPrivilegesLite, "assignGrouperPrivilegesLite",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAssignGrouperPrivilegesLiteResult.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAssignGrouperPrivilegesLiteResult, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignPermissions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAssignPermissions.java
@@ -503,16 +503,15 @@ public class GcAssignPermissions {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAssignPermissionsResults = (WsAssignPermissionsResults)
-        grouperClientWs.executeService("permissionAssignments", 
-            assignPermissions, "getPermissionAssignments", this.clientVersion, false);
+          grouperClientWs.executeService("permissionAssignments",
+              assignPermissions, "getPermissionAssignments",
+              this.clientVersion, this.contentType, false);
 
       String resultMessage = wsAssignPermissionsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAssignPermissionsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefDelete.java
@@ -240,8 +240,6 @@ public class GcAttributeDefDelete {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -249,7 +247,7 @@ public class GcAttributeDefDelete {
       //kick off the web service
       wsAttributeDefDeleteResults = (WsAttributeDefDeleteResults) grouperClientWs
           .executeService("attributeDefs", attributeDefDelete, "attributeDefDelete",
-              this.clientVersion, false);
+              this.clientVersion, this.contentType, false);
 
       String resultMessage = wsAttributeDefDeleteResults.getResultMetadata()
           .getResultMessage();

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameDelete.java
@@ -240,15 +240,15 @@ public class GcAttributeDefNameDelete {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
             
       //kick off the web service
       wsAttributeDefNameDeleteResults = (WsAttributeDefNameDeleteResults)
-        grouperClientWs.executeService("attributeDefNames", attributeDefNameDelete, "attributeDefNameDelete", this.clientVersion, false);
+          grouperClientWs.executeService("attributeDefNames",
+              attributeDefNameDelete, "attributeDefNameDelete",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAttributeDefNameDeleteResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAttributeDefNameDeleteResults, wsAttributeDefNameDeleteResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefNameSave.java
@@ -233,15 +233,15 @@ public class GcAttributeDefNameSave {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAttributeDefNameSaveResults = (WsAttributeDefNameSaveResults)
-        grouperClientWs.executeService("attributeDefNames", attributeDefNameSave, "attributeDefNameSave", this.clientVersion, false);
+        grouperClientWs.executeService("attributeDefNames",
+            attributeDefNameSave, "attributeDefNameSave",
+            this.clientVersion, this.contentType, false);
       
       String attributeDefNameSaveResultMessage = "";
       

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcAttributeDefSave.java
@@ -234,16 +234,14 @@ public class GcAttributeDefSave {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
-      wsAttributeDefSaveResults = (WsAttributeDefSaveResults) grouperClientWs
-          .executeService("attributeDefs", attributeDefSave, "attributeDefSave",
-              this.clientVersion, false);
+      wsAttributeDefSaveResults = (WsAttributeDefSaveResults)
+          grouperClientWs.executeService("attributeDefs", attributeDefSave, "attributeDefSave",
+              this.clientVersion, this.contentType, false);
 
       String attributeDefSaveResultMessage = "";
 

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcDeleteMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcDeleteMember.java
@@ -369,8 +369,6 @@ public class GcDeleteMember {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -378,7 +376,8 @@ public class GcDeleteMember {
       //kick off the web service
       String urlSuffix = "groups";
       wsDeleteMemberResults = (WsDeleteMemberResults)
-        grouperClientWs.executeService(urlSuffix, deleteMember, "deleteMember", this.clientVersion, false);
+          grouperClientWs.executeService(urlSuffix, deleteMember, "deleteMember",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsDeleteMemberResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsDeleteMemberResults, wsDeleteMemberResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectDelete.java
@@ -249,16 +249,15 @@ public class GcExternalSubjectDelete {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsExternalSubjectDeleteResults = (WsExternalSubjectDeleteResults)
-        grouperClientWs.executeService("externalSubjects", externalSubjectDelete, 
-            "externalSubjectDelete", this.clientVersion, false);
+          grouperClientWs.executeService("externalSubjects",
+              externalSubjectDelete, "externalSubjectDelete",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsExternalSubjectDeleteResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsExternalSubjectDeleteResults, wsExternalSubjectDeleteResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcExternalSubjectSave.java
@@ -231,16 +231,15 @@ public class GcExternalSubjectSave {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsExternalSubjectSaveResults = (WsExternalSubjectSaveResults)
-        grouperClientWs.executeService("externalSubjects", externalSubjectSave, "externalSubjectSave", 
-            this.clientVersion, false);
+          grouperClientWs.executeService("externalSubjects",
+              externalSubjectSave, "externalSubjectSave",
+              this.clientVersion, this.contentType, false);
       
       String groupSaveResultMessage = "";
       

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefNames.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefNames.java
@@ -533,15 +533,15 @@ public class GcFindAttributeDefNames {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsFindAttributeDefNamesResults = (WsFindAttributeDefNamesResults)
-        grouperClientWs.executeService("attributeDefNames", findAttributeDefNames, "findAttributeDefNames", this.clientVersion, true);
+          grouperClientWs.executeService("attributeDefNames",
+              findAttributeDefNames, "findAttributeDefNames",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsFindAttributeDefNamesResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsFindAttributeDefNamesResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefs.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindAttributeDefs.java
@@ -434,8 +434,6 @@ public class GcFindAttributeDefs {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -443,7 +441,7 @@ public class GcFindAttributeDefs {
       //kick off the web service
       wsFindAttributeDefsResults = (WsFindAttributeDefsResults) grouperClientWs
           .executeService("attributeDefs", findAttributeDefs, "findAttributeDefs",
-              this.clientVersion, true);
+              this.clientVersion, this.contentType, true);
 
       String resultMessage = wsFindAttributeDefsResults.getResultMetadata()
           .getResultMessage();

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindExternalSubjects.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindExternalSubjects.java
@@ -215,10 +215,7 @@ public class GcFindExternalSubjects {
       }
       findExternalSubjects.setWsExternalSubjectLookups(GrouperClientUtils.toArray(externalSubjectLookups, WsExternalSubjectLookup.class));
 
-      
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-
-      grouperClientWs.assignContentType(this.contentType);
 
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
@@ -226,7 +223,9 @@ public class GcFindExternalSubjects {
       
       //kick off the web service
       wsFindExternalSubjectsResults = (WsFindExternalSubjectsResults)
-        grouperClientWs.executeService("externalSubjects", findExternalSubjects, "findExternalSubjects", this.clientVersion, true);
+          grouperClientWs.executeService("externalSubjects",
+              findExternalSubjects, "findExternalSubjects",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsFindExternalSubjectsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsFindExternalSubjectsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindGroups.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindGroups.java
@@ -267,15 +267,14 @@ public class GcFindGroups {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsFindGroupsResults = (WsFindGroupsResults)
-        grouperClientWs.executeService("groups", findGroups, "findGroups", this.clientVersion, true);
+          grouperClientWs.executeService("groups", findGroups, "findGroups",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsFindGroupsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsFindGroupsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindStems.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcFindStems.java
@@ -249,15 +249,14 @@ public class GcFindStems {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsFindStemsResults = (WsFindStemsResults)
-        grouperClientWs.executeService("stems", findStems, "findStems", this.clientVersion, true);
+          grouperClientWs.executeService("stems", findStems, "findStems",
+              this.clientVersion,this.contentType, true);
       
       String resultMessage = wsFindStemsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsFindStemsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignActions.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignActions.java
@@ -184,8 +184,6 @@ public class GcGetAttributeAssignActions {
 
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -193,8 +191,8 @@ public class GcGetAttributeAssignActions {
       //kick off the web service
       wsGetAttributeAssignActionsResults = (WsGetAttributeAssignActionsResults)
           grouperClientWs.executeService("attributeAssignActions",
-              getAttributeAssignActions, "getAttributeAssignActions", this.clientVersion,
-              true);
+              getAttributeAssignActions, "getAttributeAssignActions",
+              this.clientVersion, this.contentType, true);
 
       String resultMessage = wsGetAttributeAssignActionsResults.getResultMetadata()
           .getResultMessage();

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignments.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAttributeAssignments.java
@@ -837,16 +837,15 @@ public class GcGetAttributeAssignments {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetAttributeAssignmentsResults = (WsGetAttributeAssignmentsResults)
-        grouperClientWs.executeService("attributeAssignments", 
-            getAttributeAssignments, "getAttributeAssignments", this.clientVersion, true);
+          grouperClientWs.executeService("attributeAssignments",
+              getAttributeAssignments, "getAttributeAssignments",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetAttributeAssignmentsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetAttributeAssignmentsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAuditEntries.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetAuditEntries.java
@@ -426,15 +426,14 @@ public class GcGetAuditEntries {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetAuditEntriesResults = (WsGetAuditEntriesResults)
-        grouperClientWs.executeService("audits", getAuditEntries, "getAuditEntries", this.clientVersion, true);
+          grouperClientWs.executeService("audits", getAuditEntries, "getAuditEntries",
+          this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetAuditEntriesResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetAuditEntriesResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGrouperPrivilegesLite.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGrouperPrivilegesLite.java
@@ -347,16 +347,15 @@ public class GcGetGrouperPrivilegesLite {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetGrouperPrivilegesLiteResult = (WsGetGrouperPrivilegesLiteResult)
-        grouperClientWs.executeService("grouperPrivileges", 
-            wsGetGrouperPrivilegesLite, "getGrouperPrivilegesLite", this.clientVersion, true);
+          grouperClientWs.executeService("grouperPrivileges",
+              wsGetGrouperPrivilegesLite, "getGrouperPrivilegesLite",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetGrouperPrivilegesLiteResult.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetGrouperPrivilegesLiteResult, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGroups.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetGroups.java
@@ -526,15 +526,14 @@ public class GcGetGroups {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetGroupsResults = (WsGetGroupsResults)
-        grouperClientWs.executeService("subjects", getGroups, "getGroups", this.clientVersion, true);
+          grouperClientWs.executeService("subjects", getGroups, "getGroups",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetGroupsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetGroupsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMembers.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMembers.java
@@ -915,15 +915,14 @@ public class GcGetMembers {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetMembersResults = (WsGetMembersResults)
-        grouperClientWs.executeService("groups", getMembers, "getMembers", this.clientVersion, true);
+          grouperClientWs.executeService("groups", getMembers, "getMembers",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetMembersResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetMembersResults, wsGetMembersResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMemberships.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetMemberships.java
@@ -941,15 +941,14 @@ public class GcGetMemberships {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetMembershipsResults = (WsGetMembershipsResults)
-        grouperClientWs.executeService("memberships", getMemberships, "getMemberships", this.clientVersion, true);
+          grouperClientWs.executeService("memberships", getMemberships, "getMemberships",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetMembershipsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetMembershipsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetPermissionAssignments.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetPermissionAssignments.java
@@ -649,16 +649,15 @@ public class GcGetPermissionAssignments {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetPermissionAssignmentsResults = (WsGetPermissionAssignmentsResults)
-        grouperClientWs.executeService("permissionAssignments", 
-            getPermissionAssignments, "getPermissionAssignments", this.clientVersion, true);
+          grouperClientWs.executeService("permissionAssignments",
+              getPermissionAssignments, "getPermissionAssignments",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetPermissionAssignmentsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetPermissionAssignmentsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetSubjects.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGetSubjects.java
@@ -361,15 +361,14 @@ public class GcGetSubjects {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGetSubjectsResults = (WsGetSubjectsResults)
-        grouperClientWs.executeService("subjects", getSubjects, "getSubjects", this.clientVersion, true);
+          grouperClientWs.executeService("subjects", getSubjects, "getSubjects",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsGetSubjectsResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGetSubjectsResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupDelete.java
@@ -256,14 +256,15 @@ public class GcGroupDelete {
       }
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
-      
+
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGroupDeleteResults = (WsGroupDeleteResults)
-        grouperClientWs.executeService("groups", groupDelete, "groupDelete", this.clientVersion, false);
+          grouperClientWs.executeService("groups", groupDelete, "groupDelete",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsGroupDeleteResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsGroupDeleteResults, wsGroupDeleteResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcGroupSave.java
@@ -249,15 +249,14 @@ public class GcGroupSave {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsGroupSaveResults = (WsGroupSaveResults)
-        grouperClientWs.executeService("groups", groupSave, "groupSave", this.clientVersion, false);
+          grouperClientWs.executeService("groups", groupSave, "groupSave",
+              this.clientVersion, this.contentType, false);
       
       String groupSaveResultMessage = "";
       

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcHasMember.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcHasMember.java
@@ -440,8 +440,6 @@ public class GcHasMember {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
@@ -451,7 +449,8 @@ public class GcHasMember {
       //MCH lets switch this to not send group name, so we can do id or name
       String urlSuffix = "groups";
       wsHasMemberResults = (WsHasMemberResults)
-        grouperClientWs.executeService(urlSuffix, hasMember, "hasMember", this.clientVersion, true);
+          grouperClientWs.executeService(urlSuffix, hasMember, "hasMember",
+              this.clientVersion, this.contentType, true);
       
       String resultMessage = wsHasMemberResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsHasMemberResults, wsHasMemberResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMemberChangeSubject.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMemberChangeSubject.java
@@ -311,15 +311,14 @@ public class GcMemberChangeSubject {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsMemberChangeSubjectResults = (WsMemberChangeSubjectResults)
-        grouperClientWs.executeService("members", memberChangeSubject, "memberChangeSubject", this.clientVersion, false);
+          grouperClientWs.executeService("members", memberChangeSubject, "memberChangeSubject",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsMemberChangeSubjectResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsMemberChangeSubjectResults, wsMemberChangeSubjectResults.getResults(),resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageAcknowledge.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageAcknowledge.java
@@ -285,15 +285,14 @@ public class GcMessageAcknowledge {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsAcknowlesgeMessageResults = (WsMessageAcknowledgeResults)
-        grouperClientWs.executeService("messaging", messageAcknowledgeRequest, "acknowledge messages", this.clientVersion, false);
+          grouperClientWs.executeService("messaging", messageAcknowledgeRequest, "acknowledge messages",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsAcknowlesgeMessageResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsAcknowlesgeMessageResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageReceive.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageReceive.java
@@ -282,15 +282,14 @@ public class GcMessageReceive {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsMessageResults = (WsMessageResults)
-        grouperClientWs.executeService("messaging", messageReceiveRequest, "receive messages", this.clientVersion, false);
+          grouperClientWs.executeService("messaging", messageReceiveRequest, "receive messages",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsMessageResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsMessageResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageSend.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcMessageSend.java
@@ -294,15 +294,14 @@ public class GcMessageSend {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsMessageResults = (WsMessageResults)
-        grouperClientWs.executeService("messaging", messageSendRequest, "send messages", this.clientVersion, false);
+          grouperClientWs.executeService("messaging", messageSendRequest, "send messages",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsMessageResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsMessageResults, null, resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemDelete.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemDelete.java
@@ -251,15 +251,14 @@ public class GcStemDelete {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsStemDeleteResults = (WsStemDeleteResults)
-        grouperClientWs.executeService("stems", stemDelete, "stemDelete", this.clientVersion, false);
+          grouperClientWs.executeService("stems", stemDelete, "stemDelete",
+              this.clientVersion, this.contentType, false);
       
       String resultMessage = wsStemDeleteResults.getResultMetadata().getResultMessage();
       grouperClientWs.handleFailure(wsStemDeleteResults, wsStemDeleteResults.getResults(), resultMessage);

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemSave.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/api/GcStemSave.java
@@ -233,15 +233,14 @@ public class GcStemSave {
       
       GrouperClientWs grouperClientWs = new GrouperClientWs();
 
-      grouperClientWs.assignContentType(this.contentType);
-
       grouperClientWs.assignWsUser(this.wsUser);
       grouperClientWs.assignWsPass(this.wsPass);
       grouperClientWs.assignWsEndpoint(this.wsEndpoint);
       
       //kick off the web service
       wsStemSaveResults = (WsStemSaveResults)
-        grouperClientWs.executeService("stems", stemSave, "stemSave", this.clientVersion, false);
+          grouperClientWs.executeService("stems", stemSave, "stemSave",
+              this.clientVersion, this.contentType, false);
       
       String stemSaveResultMessage = "";
       

--- a/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/ws/GrouperClientWs.java
+++ b/grouper-misc/grouperClient/src/java/edu/internet2/middleware/grouperClient/ws/GrouperClientWs.java
@@ -97,11 +97,6 @@ public class GrouperClientWs {
   private String resultCode = null;
   
   /**
-   * content type
-   */
-  private String contentType = null;
-  
-  /**
    * result marshaled from WS
    */
   private Object result = null;
@@ -126,7 +121,6 @@ public class GrouperClientWs {
    * @param grouperClientWs
    */
   public void copyFrom(GrouperClientWs grouperClientWs) {
-    this.contentType = grouperClientWs.contentType;
     this.method = grouperClientWs.method;
     this.response = grouperClientWs.response;
     //dont copy result
@@ -138,16 +132,6 @@ public class GrouperClientWs {
    * logger
    */
   private static Log LOG = GrouperClientUtils.retrieveLog(GrouperClientWs.class);
-
-  /**
-   * assign the content type, defaults to xml
-   * @param theContentType
-   * @return this for chaining
-   */
-  public GrouperClientWs assignContentType(String theContentType) {
-    this.contentType = theContentType;
-    return this;
-  }
 
   /**
    * 
@@ -560,7 +544,7 @@ public class GrouperClientWs {
    * @return the response object
    */
   public Object executeService(final String urlSuffix, final Object toSend, 
-      final String labelForLog, final String clientVersion, final boolean readOnly)  {
+      final String labelForLog, final String clientVersion, final String contentType, final boolean readOnly)  {
 
     GrouperClientWs grouperClientWs = null;
 
@@ -588,7 +572,7 @@ public class GrouperClientWs {
           
           //if not last connection then throw exception if not success.  If last connection then return the object
           return executeServiceHelper(failoverLogicBean.getConnectionName(), 
-              urlSuffix, toSend, labelForLog, clientVersion, !failoverLogicBean.isLastConnection(), null);
+              urlSuffix, toSend, labelForLog, clientVersion, contentType, !failoverLogicBean.isLastConnection(), null);
         }
       });
       
@@ -602,7 +586,7 @@ public class GrouperClientWs {
       }
 
       grouperClientWs = executeServiceHelper(this.wsEndpoint, 
-          urlSuffix, toSend, labelForLog, clientVersion, false, this);
+          urlSuffix, toSend, labelForLog, clientVersion, contentType, false, this);
     }
 
     if (grouperClientWs != null) {
@@ -620,7 +604,8 @@ public class GrouperClientWs {
    * @param urlSuffix e.g. groups/aStem:aGroup/members
    * @param toSend is the bean which will transform into XML, or just a string of XML to send...
    * @param labelForLog label if the request is logged to file
-   * @param clientVersion 
+   * @param clientVersion
+   * @param contentType
    * @param exceptionOnNonSuccess if non success should exception be thrown
    * @return the response object
    * @throws UnsupportedEncodingException
@@ -628,7 +613,7 @@ public class GrouperClientWs {
    * @throws IOException
    */
   private static GrouperClientWs executeServiceHelper(String url, String urlSuffix, Object toSend, String labelForLog, 
-      String clientVersion, boolean exceptionOnNonSuccess, GrouperClientWs originalGrouperClientWs)  {
+      String clientVersion, String contentType, boolean exceptionOnNonSuccess, GrouperClientWs originalGrouperClientWs)  {
     
     GrouperClientWs grouperClientWs = new GrouperClientWs();
 
@@ -665,7 +650,7 @@ public class GrouperClientWs {
     
     //make sure right content type is in request (e.g. application/xhtml+xml
     grouperClientWs.method = grouperClientWs.postMethod(url, urlSuffix, 
-        toSend, requestFile, responseCode, clientVersion);
+        toSend, requestFile, responseCode, clientVersion, contentType);
 
     //make sure a request came back
     Header successHeader = grouperClientWs.method.getResponseHeader("X-Grouper-success");
@@ -971,10 +956,10 @@ public class GrouperClientWs {
    * @throws IOException 
    */
   private PostMethod postMethod(String url, 
-      String urlSuffix, Object objectToMarshall, File logFile, int[] responseCode, String clientVersion)  {
+      String urlSuffix, Object objectToMarshall, File logFile, int[] responseCode, String clientVersion, String contentType)  {
     
     try {
-      String theContentType = GrouperClientUtils.defaultIfBlank(this.contentType, "application/json");
+      String theContentType = GrouperClientUtils.defaultIfBlank(contentType, "application/json");
       
       HttpClient httpClient = httpClient();
   


### PR DESCRIPTION
I recently created a [PR](https://github.com/Internet2/grouper/pull/212) that was merged however the changes were not working as intended. The contentType was not being passed properly from the Gc classes into GrouperClientWs, leaving the contentType as null and replaced by the default `application/json` format upon executing a post request. This time it works properly, the contentType is passed in similar to how clientVersion is passed into GrouperClientWs.