### PR TITLE
Fix LDAP paging configuration.

### DIFF
--- a/grouper-parent/pom.xml
+++ b/grouper-parent/pom.xml
@@ -163,7 +163,7 @@
         <p6spy.version>3.6.0</p6spy.version>
         <postgresql.version>42.5.1</postgresql.version>
         <mysql.connector.java.version>8.0.33</mysql.connector.java.version>
-        <ldaptive.version>2.2.1-SNAPSHOT</ldaptive.version>
+        <ldaptive.version>2.3.1-SNAPSHOT</ldaptive.version>
         <unboundid.version>6.0.10</unboundid.version>
         <aws.java.sdk.core>1.12.267</aws.java.sdk.core>
         <aws.java.sdk.s3>1.12.267</aws.java.sdk.s3>

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImpl.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImpl.java
@@ -16,6 +16,7 @@
 package edu.internet2.middleware.grouper.ldap.ldaptive;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -470,26 +471,35 @@ public class LdaptiveSessionImpl implements LdapSession {
     if (this.debug) {
       this.debugLog.append("Ldaptive searchRequest (").append(ldapServerId).append("): ").append(StringUtils.abbreviate(searchRequest.toString(), 2000)).append("\n");
     }
+    LdapEntryHandler[] entryHandlers = LdaptiveConfiguration.getConfig(ldapServerId).getLdapEntryHandlers();
+    List<SearchResultHandler> resultHandlers = new ArrayList<>(Arrays.asList(LdaptiveConfiguration.getConfig(ldapServerId).getSearchResultHandlers()));
+    if ("follow".equals(GrouperLoaderConfig.retrieveConfig().propertyValueString("ldap." + ldapServerId + ".referral"))) {
+      resultHandlers.add(new FollowSearchReferralHandler());
+      resultHandlers.add(new FollowSearchResultReferenceHandler());
+    }
     if (pageSize == null) {
       SearchOperation search = new SearchOperation(ldap);
       search.setThrowCondition(result -> 
         !result.getResultCode().equals(ResultCode.SUCCESS) && 
         !ldapConfig.getSearchIgnoreResultCodes().contains(result.getResultCode()));
-      LdapEntryHandler[] entryHandlers = LdaptiveConfiguration.getConfig(ldapServerId).getLdapEntryHandlers();
-
       if (entryHandlers != null) {
         search.setEntryHandlers(entryHandlers);
       }
-      SearchResultHandler[] resultHandlers = LdaptiveConfiguration.getConfig(ldapServerId).getSearchResultHandlers();
-      if (resultHandlers != null) {
-        search.setSearchResultHandlers(resultHandlers);
-      }
-      if ("follow".equals(GrouperLoaderConfig.retrieveConfig().propertyValueString("ldap." + ldapServerId + ".referral"))) {
-        search.setSearchResultHandlers(new FollowSearchReferralHandler(), new FollowSearchResultReferenceHandler());
+      if (!resultHandlers.isEmpty()) {
+        search.setSearchResultHandlers(resultHandlers.toArray(new SearchResultHandler[0]));
       }
       response = search.execute(searchRequest);
     } else {
       PagedResultsClient client = new PagedResultsClient(ldap, pageSize);
+      client.setThrowCondition(result ->
+        !result.getResultCode().equals(ResultCode.SUCCESS) &&
+          !ldapConfig.getSearchIgnoreResultCodes().contains(result.getResultCode()));
+      if (entryHandlers != null) {
+        client.setEntryHandlers(entryHandlers);
+      }
+      if (!resultHandlers.isEmpty()) {
+        client.setSearchResultHandlers(resultHandlers.toArray(new SearchResultHandler[0]));
+      }
       response = client.executeToCompletion(searchRequest);
     }
     if (this.debug) {


### PR DESCRIPTION
Entry handlers and result handlers were not set on the PagedResultsClient. Update so that the paged results client is configured the same as the search operation. Fix bug that would override result handlers if referral chasing was configured.