### PR TITLE
GRP-5274: Allow dashes in ConfigIds

### DIFF
--- a/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/serviceLogic/UiV2Template.java
+++ b/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/serviceLogic/UiV2Template.java
@@ -77,7 +77,7 @@ public class UiV2Template {
   
   
   private static Pattern grouperTemplateServiceClassPattern = Pattern.compile(
-      "^grouper\\.template\\.(\\w+)\\.logicClass$");
+      "^grouper\\.template\\.([\\w-]+)\\.logicClass$");
   
   /**
    * keep an expirable cache of import progress for 5 hours (longest an import is expected).  This has multikey of session id and some random uuid
@@ -846,7 +846,7 @@ public class UiV2Template {
         return false;
       }
       
-      String regex = "^[a-zA-Z0-9_]*$";
+      String regex = "^[a-zA-Z0-9_-]*$";
       if (!templateKey.matches(regex)) {
         guiResponseJs.addAction(GuiScreenAction.newValidationMessage(GuiMessageType.error,
             "#serviceKeyId",

--- a/grouper/conf/grouper-loader.base.properties
+++ b/grouper/conf/grouper-loader.base.properties
@@ -333,13 +333,13 @@ loader.unresolvables.maxPercentForSuccess = 5
 #################################
 ## DB connections
 ## specify the db connection with user, pass, url, and driver class
-## the string after "db." is the name of the connection, and it should not have
-## spaces or other special chars in it
+## the string after "db." is the name of the connection, and it must
+## contain only alphanumeric, underscore, or dash. eg: mylogin
 #################################
 
 # specify the db connection with user, pass, url, and driver class
-# the string after "db." is the name of the connection, and it should not have
-# spaces or other special chars in it. eg: mylogin
+# the string after "db." is the name of the connection, and it must
+### contain only alphanumeric, underscore, or dash. eg: mylogin
 # {valueType: "string", required: true, regex: "^db\\.([^.]+)\\.user$"}
 # db.warehouse.user =
 
@@ -425,8 +425,8 @@ grouperLoader.db.connections.pool = true
 #################################
 
 # specify the ldap connection with user, pass, url
-# the string after "ldap." is the ID of the connection, and it should not have
-# spaces or other special chars in it.
+# the string after "ldap." is the ID of the connection, and it must
+#### contain only alphanumeric, underscore, or dash.
 # note the URL should start with ldap:  or ldaps: if it is SSL.  
 # It should contain the server and port (optional if not default), and baseDn, 
 # e.g. ldaps://ldapserver.school.edu:636/dc=school,dc=edu
@@ -4531,8 +4531,8 @@ grouper.provisioning.removeSyncLogRowsAfterDays = 7
 ############################################
 ## Azure external system
 ## specify the azure connection with user, pass, endpoint etc
-## the string after "azureConnector." is the name of the connection, and it should not have
-## spaces or other special chars in it
+## the string after "azureConnector." is the name of the connection, and it must
+#### contain only alphanumeric, underscore, or dash
 ############################################
 
 # azure login base uri to get a token. Should end in a slash.  e.g. https://login.microsoftonline.com/
@@ -4606,8 +4606,8 @@ teamDynamixAuthnTokenExpiresSeconds = 60
 ############################################
 ## TeamDynamix external system
 ## specify the TeamDynamix connection with user, pass, endpoint etc
-## the string after "teamDynamix." is the name of the connection, and it should not have
-## spaces or other special chars in it
+## the string after "teamDynamix." is the name of the connection, and it must
+#### contain only alphanumeric, underscore, or dash
 ############################################
 
 # TeamDynamix login base uri to get a token. Should end in a slash.  e.g. https://yourTeamDynamixDomain/

--- a/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
@@ -13300,7 +13300,7 @@ grouperConfigurationValidationElRequired = Error: '${configFieldLabel}' is selec
 grouperConfigurationValidationRequired = Error: '${configFieldLabel}' is required
 grouperConfigurationValidationConfigIdUsed = Error: the '$$configIdLabel$$' is already in use, please select another or edit that config
 grouperConfigurationValidationConfigIdDoesntExist = Error: the '$$configIdLabel$$' does not exist
-grouperConfigurationValidationConfigIdInvalid = Error: the '$$configIdLabel$$' must only contain alphanumeric characters or underscore
+grouperConfigurationValidationConfigIdInvalid = Error: the '$$configIdLabel$$' must only contain alphanumeric characters, underscore, or dash
 grouperConfigurationValidationTestSqlQueryRequired = Error: '${configFieldLabel}' is required when test expected value is provided
 grouperConfigurationTestExpectedNotMatchingResult = Error: expected '$$expectedValue$$' but received '$$receivedValue$$'
 

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/config/GrouperConfigurationModuleBase.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/config/GrouperConfigurationModuleBase.java
@@ -365,7 +365,7 @@ public abstract class GrouperConfigurationModuleBase {
     }
 
     if (isMultiple()) {
-      Pattern configIdPattern = Pattern.compile("^[a-zA-Z0-9_]+$");
+      Pattern configIdPattern = Pattern.compile("^[\\w-]+$");
       if (!configIdPattern.matcher(this.getConfigId()).matches()) {
         validationErrorsToDisplay.put("#configId", GrouperTextContainer.textOrNull("grouperConfigurationValidationConfigIdInvalid"));
       }

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/daemon/GrouperDaemonConfiguration.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/daemon/GrouperDaemonConfiguration.java
@@ -134,7 +134,7 @@ public abstract class GrouperDaemonConfiguration extends GrouperConfigurationMod
       if (!this.retrieveConfigurationConfigIds().contains(this.getConfigId())) {
         validationErrorsToDisplay.put("#configId", GrouperTextContainer.textOrNull("grouperConfigurationValidationConfigIdDoesntExist"));
       }
-      Pattern configIdPattern = Pattern.compile("^[a-zA-Z0-9_]+$");
+      Pattern configIdPattern = Pattern.compile("^[a-zA-Z0-9_-]+$");
       if (!configIdPattern.matcher(this.getConfigId()).matches()) {
         validationErrorsToDisplay.put("#configId", GrouperTextContainer.textOrNull("grouperConfigurationValidationConfigIdInvalid"));
       }

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningSettings.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningSettings.java
@@ -16,7 +16,7 @@ import edu.internet2.middleware.grouperClient.util.ExpirableCache;
 
 public class GrouperProvisioningSettings {
   
-  private static final Pattern grouperProvisioningTargetKey = Pattern.compile("^provisioner\\.(\\w+)\\.class$");
+  private static final Pattern grouperProvisioningTargetKey = Pattern.compile("^provisioner\\.([\\w-]+)\\.class$");
   
   private static ExpirableCache<Boolean, Map<String, GrouperProvisioningTarget>> __targetsCacheInternal;
 

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/reports/GrouperReportJob.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/reports/GrouperReportJob.java
@@ -69,7 +69,7 @@ public class GrouperReportJob implements Job {
   
         @Override
         public Object callback(GrouperSession grouperSession) throws GrouperSessionException {
-          Pattern grouperReportingJobNamePattern = Pattern.compile("^grouper_report_([a-zA-Z0-9]+)_(\\w+)$");
+          Pattern grouperReportingJobNamePattern = Pattern.compile("^grouper_report_([a-zA-Z0-9]+)_([\\w-]+)$");
           
           long startTime = System.currentTimeMillis();
           

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/usdu/UsduJob.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/usdu/UsduJob.java
@@ -97,7 +97,7 @@ public class UsduJob extends OtherJobBase {
   
   private static void populateUsduConfiguredSources() {
     
-    Pattern usduSourceIdKey = Pattern.compile("^usdu\\.source\\.(\\w+)\\.sourceId$");
+    Pattern usduSourceIdKey = Pattern.compile("^usdu\\.source\\.([\\w-]+)\\.sourceId$");
     
     SourceManager.getInstance().getSources();
     
@@ -344,7 +344,7 @@ public class UsduJob extends OtherJobBase {
 
     int totalObjectsStored = 0;
     
-    Pattern provisionerPatternWithMemberInfo = Pattern.compile("^provisioner\\.(\\w+)\\.(entityAttributeValueCache0has|entityAttributeValueCache1has|entityAttributeValueCache2has|entityAttributeValueCache3has)$");    
+    Pattern provisionerPatternWithMemberInfo = Pattern.compile("^provisioner\\.([\\w-]+)\\.(entityAttributeValueCache0has|entityAttributeValueCache1has|entityAttributeValueCache2has|entityAttributeValueCache3has)$");
     Map<String, String> provisionerPropsWithMemberInfo = GrouperLoaderConfig.retrieveConfig().propertiesMap(provisionerPatternWithMemberInfo);
     Set<String> configNames = new HashSet<String>();
     for (String property : provisionerPropsWithMemberInfo.keySet()) {

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/misc/GrouperCheckConfig.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/misc/GrouperCheckConfig.java
@@ -2097,25 +2097,25 @@ public class GrouperCheckConfig {
    * match something like this: db.warehouse.pass
    */
   private static Pattern grouperLoaderDbPattern = Pattern.compile(
-      "^db\\.(\\w+)\\.(pass|url|driver|user)$");
+      "^db\\.([\\w-]+)\\.(pass|url|driver|user)$");
   
   /**
    * match something like this: changeLog.consumer.ldappc.class, changeLog.consumer.ldappc.quartzCron
    */
   public static Pattern grouperLoaderConsumerPattern = Pattern.compile(
-      "^changeLog\\.consumer\\.(\\w+)\\.(class|quartzCron)$");
+      "^changeLog\\.consumer\\.([\\w-]+)\\.(class|quartzCron)$");
   
   /**
    * match something like this: changeLog.consumer.ldappc.class, changeLog.consumer.ldappc.quartzCron
    */
   public static Pattern messagingListenerConsumerPattern = Pattern.compile(
-      "^messaging\\.listener\\.(\\w+)\\.(.*)$");
+      "^messaging\\.listener\\.([\\w-]+)\\.(.*)$");
   
   /**
    * match something like this: otherJob.duo.class, otherJob.duo.quartzCron, otherJob.duo.priority
    */
   public static Pattern grouperLoaderOtherJobPattern = Pattern.compile(
-      "^otherJob\\.(\\w+)\\.(class|quartzCron|priority)$");
+      "^otherJob\\.([\\w-]+)\\.(class|quartzCron|priority)$");
   
   /**
    * <pre>


### PR DESCRIPTION
Fix in V4.  `[a-zA-Z0-9_]` -> `[a-zA-Z0-9_-]`

Tested: 
  - External systems
    - Azure
    - Box
    - Database
    - Google
    - Ldap
    - RabbitMq
    - SMTP
    - TeamDynamix
    - WS (bearer token or basic authn)

  - provisioning
    - Ldap

  - Subject sources
    - Ldap
    - SQL

  - GSH Templates
    - V1
    - V2

  - Daemons
    - Provisioner full/increemental
    - CSV report
    - SQL Sync
    - Script daemon
    - Changelog GSH
