### PR TITLE
GRP-5539: don't throw on referral if follow is set

### DIFF
--- a/grouper/pom.xml
+++ b/grouper/pom.xml
@@ -378,6 +378,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.12.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>net.redhogs.cronparser</groupId>
             <artifactId>cron-parser-core</artifactId>
         </dependency>

--- a/grouper/src/test/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImplTest.java
+++ b/grouper/src/test/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImplTest.java
@@ -25,6 +25,7 @@ import java.util.Properties;
 import com.unboundid.ldap.listener.InMemoryDirectoryServer;
 import com.unboundid.ldap.listener.InMemoryDirectoryServerConfig;
 import com.unboundid.ldap.listener.InMemoryListenerConfig;
+import com.unboundid.ldap.sdk.OperationType;
 import com.unboundid.ldif.LDIFReader;
 import edu.internet2.middleware.grouper.app.loader.GrouperLoaderConfig;
 import edu.internet2.middleware.grouper.ldap.LdapAttribute;
@@ -32,108 +33,155 @@ import edu.internet2.middleware.grouper.ldap.LdapEntry;
 import edu.internet2.middleware.grouper.ldap.LdapModificationItem;
 import edu.internet2.middleware.grouper.ldap.LdapModificationType;
 import edu.internet2.middleware.grouper.ldap.LdapSearchScope;
+import edu.internet2.middleware.grouperClient.config.db.ConfigDatabaseLogic;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import static org.mockito.ArgumentMatchers.anyString;
 
 /**
  * Unit test for {@link LdaptiveSessionImpl}.
  */
 public class LdaptiveSessionImplTest {
 
-  private static final String TEST_LDAP_PROPERTIES =
-    "ldap.testLDAP.url = ldap://localhost:%PORT%\n"
-      + "ldap.testLDAP.tls = false\n"
-      + "ldap.testLDAP.sizeLimit = 10\n"
-      + "ldap.testLDAP.timeLimit = PT5S\n"
-      + "ldap.testLDAP.connectTimeout = PT3S\n"
-      + "ldap.testLDAP.responseTimeout = PT3S\n"
-      + "ldap.testLDAP.minPoolSize = 2\n"
-      + "ldap.testLDAP.maxPoolSize = 5\n"
-      + "ldap.testLDAP.blockWaitTime = PT1S\n"
-      + "ldap.testLDAP.blockWaitTime = PT1S\n"
-      + "ldap.testLDAP.pruneTimerPeriod = 420000\n"
-      + "ldap.testLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler\n"
-      + "ldap.testPagingLDAP.url = ldap://localhost:%PORT%\n"
-      + "ldap.testPagingLDAP.tls = false\n"
-      + "ldap.testPagingLDAP.sizeLimit = 10\n"
-      + "ldap.testPagingLDAP.timeLimit = PT5S\n"
-      + "ldap.testPagingLDAP.connectTimeout = PT3S\n"
-      + "ldap.testPagingLDAP.responseTimeout = PT3S\n"
-      + "ldap.testPagingLDAP.minPoolSize = 2\n"
-      + "ldap.testPagingLDAP.maxPoolSize = 5\n"
-      + "ldap.testPagingLDAP.blockWaitTime = PT1S\n"
-      + "ldap.testPagingLDAP.blockWaitTime = PT1S\n"
-      + "ldap.testPagingLDAP.pruneTimerPeriod = 420000\n"
-      + "ldap.testPagingLDAP.pagedResultsSize = 2\n"
-      + "ldap.testPagingLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler";
+  private static final String TEST_LDAP_PROPERTIES = """
+    ldap.testLDAP.url = ldap://localhost:%PORT%
+    ldap.testLDAP.tls = false
+    ldap.testLDAP.bindDn = cn=manager,dc=internet2,dc=edu
+    ldap.testLDAP.bindCredential = p@ssw0rd0
+    ldap.testLDAP.sizeLimit = 10
+    ldap.testLDAP.timeLimit = PT5S
+    ldap.testLDAP.connectTimeout = PT3S
+    ldap.testLDAP.responseTimeout = PT3S
+    ldap.testLDAP.minPoolSize = 2
+    ldap.testLDAP.maxPoolSize = 5
+    ldap.testLDAP.blockWaitTime = PT1S
+    ldap.testLDAP.blockWaitTime = PT1S
+    ldap.testLDAP.pruneTimerPeriod = 420000
+    ldap.testLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler
+    ldap.testPagingLDAP.url = ldap://localhost:%PORT%
+    ldap.testPagingLDAP.tls = false
+    ldap.testPagingLDAP.bindDn = cn=manager,dc=internet2,dc=edu
+    ldap.testPagingLDAP.bindCredential = p@ssw0rd0
+    ldap.testPagingLDAP.sizeLimit = 10
+    ldap.testPagingLDAP.timeLimit = PT5S
+    ldap.testPagingLDAP.connectTimeout = PT3S
+    ldap.testPagingLDAP.responseTimeout = PT3S
+    ldap.testPagingLDAP.minPoolSize = 2
+    ldap.testPagingLDAP.maxPoolSize = 5
+    ldap.testPagingLDAP.blockWaitTime = PT1S
+    ldap.testPagingLDAP.blockWaitTime = PT1S
+    ldap.testPagingLDAP.pruneTimerPeriod = 420000
+    ldap.testPagingLDAP.pagedResultsSize = 2
+    ldap.testPagingLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler
+    ldap.testReferralLDAP.url = ldap://localhost:%PORT%
+    ldap.testReferralLDAP.tls = false
+    ldap.testReferralLDAP.bindDn = cn=manager,dc=internet2,dc=edu
+    ldap.testReferralLDAP.bindCredential = p@ssw0rd0
+    ldap.testReferralLDAP.sizeLimit = 10
+    ldap.testReferralLDAP.timeLimit = PT5S
+    ldap.testReferralLDAP.connectTimeout = PT3S
+    ldap.testReferralLDAP.responseTimeout = PT3S
+    ldap.testReferralLDAP.minPoolSize = 2
+    ldap.testReferralLDAP.maxPoolSize = 5
+    ldap.testReferralLDAP.blockWaitTime = PT1S
+    ldap.testReferralLDAP.blockWaitTime = PT1S
+    ldap.testReferralLDAP.pruneTimerPeriod = 420000
+    ldap.testReferralLDAP.referral = follow
+    ldap.testReferralLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler
+    ldap.testPagingReferralLDAP.url = ldap://localhost:%PORT%
+    ldap.testPagingReferralLDAP.tls = false
+    ldap.testPagingReferralLDAP.bindDn = cn=manager,dc=internet2,dc=edu
+    ldap.testPagingReferralLDAP.bindCredential = p@ssw0rd0
+    ldap.testPagingReferralLDAP.sizeLimit = 10
+    ldap.testPagingReferralLDAP.timeLimit = PT5S
+    ldap.testPagingReferralLDAP.connectTimeout = PT3S
+    ldap.testPagingReferralLDAP.responseTimeout = PT3S
+    ldap.testPagingReferralLDAP.minPoolSize = 2
+    ldap.testPagingReferralLDAP.maxPoolSize = 5
+    ldap.testPagingReferralLDAP.blockWaitTime = PT1S
+    ldap.testPagingReferralLDAP.blockWaitTime = PT1S
+    ldap.testPagingReferralLDAP.pruneTimerPeriod = 420000
+    ldap.testPagingReferralLDAP.pagedResultsSize = 1
+    ldap.testPagingReferralLDAP.referral = follow
+    ldap.testPagingReferralLDAP.searchResultHandlers = edu.vt.middleware.ldap.handler.EntryDnSearchResultHandler
+    """;
 
-  private static final String TEST_LDAP_LDIF =
-    "dn: dc=internet2,dc=edu\n"
-      + "dc: internet2\n"
-      + "objectClass: dcObject\n"
-      + "objectClass: organization\n"
-      + "o: Internet2\n"
-      + "\n"
-      + "dn: ou=people,dc=internet2,dc=edu\n"
-      + "ou: people\n"
-      + "description: All people in organization\n"
-      + "objectclass: organizationalunit\n"
-      + "\n"
-      + "dn: uid=bbacharach,ou=people,dc=internet2,dc=edu\n"
-      + "objectclass: inetOrgPerson\n"
-      + "cn: Burt Bacharach\n"
-      + "givenName: Burt\n"
-      + "sn: Bacharach\n"
-      + "uid: bbacharach\n"
-      + "uidNumber: 1001\n"
-      + "userPassword: p@ssw0rd1\n"
-      + "mail: bbacharach@internet2.edu\n"
-      + "mail: burt.bacharach@internet2.edu\n"
-      + "telephoneNumber: 8169894342\n"
-      + "\n"
-      + "dn: uid=dwarwick,ou=people,dc=internet2,dc=edu\n"
-      + "objectclass: inetOrgPerson\n"
-      + "cn: Dionne Warwick\n"
-      + "givenName: Dionne\n"
-      + "sn: Warwick\n"
-      + "uid: dwarwick\n"
-      + "uidNumber: 1002\n"
-      + "userPassword: p@ssw0rd2\n"
-      + "mail: dwarwick@internet2.edu\n"
-      + "mail: dionne.warwick@internet2.edu\n"
-      + "telephoneNumber: 8169894343\n"
-      + "\n"
-      + "dn: uid=bmanilow,ou=people,dc=internet2,dc=edu\n"
-      + "objectclass: inetOrgPerson\n"
-      + "cn: Barry Manilow\n"
-      + "givenName: Barry\n"
-      + "sn: Manilow\n"
-      + "uid: bmanilow\n"
-      + "uidNumber: 1003\n"
-      + "userPassword: p@ssw0rd3\n"
-      + "mail: bmanilow@internet2.edu\n"
-      + "mail: barry.manilow@internet2.edu\n"
-      + "telephoneNumber: 8169894344\n"
-      + "\n"
-      + "dn: uid=gpitney,ou=people,dc=internet2,dc=edu\n"
-      + "objectclass: inetOrgPerson\n"
-      + "cn: Gene Pitney\n"
-      + "givenName: Gene\n"
-      + "sn: Pitney\n"
-      + "uid: gpitney\n"
-      + "uidNumber: 1004\n"
-      + "userPassword: p@ssw0rd4\n"
-      + "mail: gpitney@internet2.edu\n"
-      + "mail: gene.pitney@internet2.edu\n"
-      + "telephoneNumber: 8169894345\n";
+  private static final String TEST_LDAP_LDIF = """
+    dn: dc=internet2,dc=edu
+    dc: internet2
+    objectClass: dcObject
+    objectClass: organization
+    o: Internet2
+    
+    dn: ou=people,dc=internet2,dc=edu
+    ou: people
+    description: All people in organization
+    objectclass: organizationalunit
+    
+    dn: uid=bbacharach,ou=people,dc=internet2,dc=edu
+    objectclass: inetOrgPerson
+    cn: Burt Bacharach
+    givenName: Burt
+    sn: Bacharach
+    uid: bbacharach
+    uidNumber: 1001
+    userPassword: p@ssw0rd1
+    mail: bbacharach@internet2.edu
+    mail: burt.bacharach@internet2.edu
+    telephoneNumber: 8169894342
+    
+    dn: uid=dwarwick,ou=people,dc=internet2,dc=edu
+    objectclass: inetOrgPerson
+    cn: Dionne Warwick
+    givenName: Dionne
+    sn: Warwick
+    uid: dwarwick
+    uidNumber: 1002
+    userPassword: p@ssw0rd2
+    mail: dwarwick@internet2.edu
+    mail: dionne.warwick@internet2.edu
+    telephoneNumber: 8169894343
+    
+    dn: uid=bmanilow,ou=people,dc=internet2,dc=edu
+    objectclass: inetOrgPerson
+    cn: Barry Manilow
+    givenName: Barry
+    sn: Manilow
+    uid: bmanilow
+    uidNumber: 1003
+    userPassword: p@ssw0rd3
+    mail: bmanilow@internet2.edu
+    mail: barry.manilow@internet2.edu
+    telephoneNumber: 8169894344
+    
+    dn: uid=gpitney,ou=people,dc=internet2,dc=edu
+    objectclass: inetOrgPerson
+    cn: Gene Pitney
+    givenName: Gene
+    sn: Pitney
+    uid: gpitney
+    uidNumber: 1004
+    userPassword: p@ssw0rd4
+    mail: gpitney@internet2.edu
+    mail: gene.pitney@internet2.edu
+    telephoneNumber: 8169894345
+    """;
 
   /** Properties configuration id used for testing. */
   private static final String SERVER_ID = "testLDAP";
 
   /** Properties configuration id used for testing. */
   private static final String SERVER_ID_PAGING = "testPagingLDAP";
+
+  /** Properties configuration id used for testing. */
+  private static final String SERVER_ID_REFERRAL = "testReferralLDAP";
+
+  /** Properties configuration id used for testing. */
+  private static final String SERVER_ID_PAGING_REFERRAL = "testPagingReferralLDAP";
 
   /** LDAP server to test against. */
   private static InMemoryDirectoryServer server;
@@ -144,10 +192,15 @@ public class LdaptiveSessionImplTest {
   /** Object to test. */
   private static LdaptiveSessionImpl session;
 
+  /** Mock to prevent database initialization. */
+  private static MockedStatic<ConfigDatabaseLogic> databaseLoader;
+
   @BeforeClass
   public static void setup() throws Exception {
     final InMemoryDirectoryServerConfig config = new InMemoryDirectoryServerConfig("dc=internet2,dc=edu");
     config.setSchema(null);
+    config.setAuthenticationRequiredOperationTypes(OperationType.SEARCH);
+    config.addAdditionalBindCredentials("cn=manager,dc=internet2,dc=edu", "p@ssw0rd0");
     final InMemoryListenerConfig listenerConfig = new InMemoryListenerConfig(
       "in-memory-ldap",
       InetAddress.getLoopbackAddress(),
@@ -167,6 +220,17 @@ public class LdaptiveSessionImplTest {
       throw new RuntimeException("Could not start in memory LDAP server", e);
     }
 
+    // add a referral entry to the server.
+    server.add(
+      "dn: ou=referral,dc=internet2,dc=edu",
+      "objectClass: top",
+      "objectClass: referral",
+      "objectClass: extensibleObject",
+      "ou: referral",
+      "ref: " + "ldap://localhost:" + serverPort + "/ou=people,dc=internet2,dc=edu");
+
+    databaseLoader = Mockito.mockStatic(ConfigDatabaseLogic.class);
+    databaseLoader.when(() -> ConfigDatabaseLogic.retrieveConfigInputStream(anyString())).thenReturn(null);
     overrideProperties(TEST_LDAP_PROPERTIES.replaceAll("%PORT%", serverPort));
     session = new LdaptiveSessionImpl();
   }
@@ -174,6 +238,7 @@ public class LdaptiveSessionImplTest {
   @AfterClass
   public static void teardown() {
     session.refreshConnectionsIfNeeded(SERVER_ID);
+    databaseLoader.close();
     if (server != null) {
       server.shutDown(true);
     }
@@ -220,6 +285,34 @@ public class LdaptiveSessionImplTest {
     List<LdapEntry> entries = session.list(
       SERVER_ID_PAGING,
       "ou=people,dc=internet2,dc=edu",
+      LdapSearchScope.SUBTREE_SCOPE,
+      "(uid=*)",
+      new String[] {"uid", "givenName", "entryDn"},
+      10);
+    Assert.assertNotNull(entries);
+    Assert.assertEquals(4, entries.size());
+    Assert.assertNotNull(entries.get(0).getAttribute("entryDn").getStringValues().iterator().next());
+  }
+
+  @Test
+  public void listReferral() {
+    List<LdapEntry> entries = session.list(
+      SERVER_ID_REFERRAL,
+      "ou=referral,dc=internet2,dc=edu",
+      LdapSearchScope.SUBTREE_SCOPE,
+      "(uid=*)",
+      new String[] {"uid", "givenName", "entryDn"},
+      10);
+    Assert.assertNotNull(entries);
+    Assert.assertEquals(4, entries.size());
+    Assert.assertNotNull(entries.get(0).getAttribute("entryDn").getStringValues().iterator().next());
+  }
+
+  @Test
+  public void listPagingReferral() {
+    List<LdapEntry> entries = session.list(
+      SERVER_ID_PAGING_REFERRAL,
+      "ou=referral,dc=internet2,dc=edu",
       LdapSearchScope.SUBTREE_SCOPE,
       "(uid=*)",
       new String[] {"uid", "givenName", "entryDn"},


### PR DESCRIPTION
Update LdaptiveSessionImpl to ignore referral result codes when following referrals. Add IgnoreResultCodePredicate to provide logging.
Update unit test to include referrals.
Add mockito dependency to avoid database initialization in unit test.