### PR TITLE
GRP-5070: Job log include elapsed time in something besides millisecond

### DIFF
--- a/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/beans/api/GuiHib3GrouperLoaderLog.java
+++ b/grouper-ui/java/src/edu/internet2/middleware/grouper/grouperUi/beans/api/GuiHib3GrouperLoaderLog.java
@@ -7,6 +7,7 @@ package edu.internet2.middleware.grouper.grouperUi.beans.api;
 import java.util.ArrayList;
 import java.util.List;
 
+import edu.internet2.middleware.grouper.ui.GrouperUiFilter;
 import org.apache.commons.lang.StringUtils;
 
 import edu.internet2.middleware.grouper.Group;
@@ -17,7 +18,7 @@ import edu.internet2.middleware.grouper.app.loader.db.Hib3GrouperLoaderLog;
 import edu.internet2.middleware.grouper.grouperUi.beans.ui.GrouperLoaderContainer;
 import edu.internet2.middleware.grouper.ui.util.GrouperUiConfig;
 import edu.internet2.middleware.grouper.util.GrouperUtil;
-
+import java.util.Locale;
 
 /**
  * gui class to display a loader log
@@ -37,7 +38,7 @@ public class GuiHib3GrouperLoaderLog {
    * gui group of group being loaded if applicable
    */
   private GuiGroup loadedGuiGroup;
-  
+
   /**
    * get the loaded group, not null if there are multiple
    * @return the loaded group
@@ -244,4 +245,78 @@ public class GuiHib3GrouperLoaderLog {
   public GuiHib3GrouperLoaderLog() {
   }
 
+  private String convertMillisToTime(Integer millis) {
+    String unit = GrouperUiConfig.retrieveConfig().propertyValueString("uiV2.admin.daemonJob.elapsedTimeUnit", "milliseconds");
+
+    if (millis == null) {
+      return null;
+    }
+
+    if (millis == 0) {
+      return "0";
+    }
+
+    Locale locale = GrouperUiFilter.retrieveLocale();
+    String result;
+
+    switch (unit) {
+      case "seconds":
+        result = String.format(locale, "%.2f", millis / 1000f);
+        break;
+      case "minutes":
+        result = String.format(locale, "%.2f", millis/60000f);
+        break;
+      case "h:m:s":
+        long millis2 = millis;
+        long hours2 = millis2 / (1000 * 60 * 60);
+        millis2 %= (1000 * 60 * 60);
+        long minutes2 = millis2 / (1000 * 60);
+        millis2 %= (1000 * 60);
+        long seconds2 = millis2 / 1000;
+        long ms2 = millis2 % 1000;
+
+        result = String.format("%d:%02d:%02d.%03d", hours2, minutes2, seconds2, ms2);
+        break;
+      case "hms":
+        long millis3 = millis;
+        long hours3 = millis3 / (1000 * 60 * 60);
+        millis3 %= (1000 * 60 * 60);
+        long minutes3 = millis3 / (1000 * 60);
+        millis3 %= (1000 * 60);
+        float seconds3 = millis3 / 1000f;
+
+        StringBuffer buffer = new StringBuffer();
+        if (hours3 > 0) {
+          buffer.append(hours3 + "h");
+        }
+        if (hours3 > 0 || minutes3 > 0) {
+          buffer.append(minutes3 + "m");
+        }
+        if (hours3 > 0 || minutes3 > 0 || seconds3 > 0) {
+          buffer.append(String.format(locale, "%.2f", seconds3) + "s");
+        } else {
+          buffer.append(millis3 + "ms");
+        }
+
+        result = buffer.toString();
+        break;
+      case "milliseconds":
+      default:
+        result = millis.toString();
+    }
+
+    return result;
+  }
+
+  public String getTotalElapsedFormatted() {
+    return convertMillisToTime(hib3GrouperLoaderLog.getMillis());
+  }
+
+  public String getGetDataElapsedFormatted() {
+    return convertMillisToTime(hib3GrouperLoaderLog.getMillisGetData());
+  }
+
+  public String getLoadDataElapsedFormatted() {
+    return convertMillisToTime(hib3GrouperLoaderLog.getMillisLoadData());
+  }
 }

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobsViewLogsResults.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobsViewLogsResults.jsp
@@ -99,9 +99,9 @@
                         
                         <td style="white-space: nowrap">${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.startedTime}</td>
                         <td style="white-space: nowrap">${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.endedTime}</td>
-                        <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.millis}</td>
-                        <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.millisGetData}</td>
-                        <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.millisLoadData}</td>
+                        <td>${guiHib3GrouperLoaderLog.totalElapsedFormatted}</td>
+                        <td>${guiHib3GrouperLoaderLog.getDataElapsedFormatted}</td>
+                        <td>${guiHib3GrouperLoaderLog.loadDataElapsedFormatted}</td>
                         <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.totalCount}</td>
                         <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.insertCount}</td>
                         <td>${guiHib3GrouperLoaderLog.hib3GrouperLoaderLog.updateCount}</td>

--- a/grouper/conf/grouper-ui-ng.base.properties
+++ b/grouper/conf/grouper-ui-ng.base.properties
@@ -1443,6 +1443,12 @@ uiV2.admin.daemonJob.commonFilterAdditions =
 # {valueType: "string", required: false}
 uiV2.admin.daemonJob.extendedSchedule.dateFormat = yyyy-MM-dd HH:mm:ss z
 
+# Loader log format for elapsed time, get data, and load data columns. Options 'seconds' or 'minutes' will format
+# to 2 decimal places. Option 'h:m:s' will format as time, e.g. 27:15:20.24. Option 'hms' will format as '27h15M20.74s'.
+# You may also want to override text properties starting with grouperLoaderLogsMillis... so the headers are accurate
+# {valueType: "string", required: false, formElement: "dropdown", optionValues: ["milliseconds", "seconds", "minutes", "h:m:s", "hms"]}
+uiV2.admin.daemonJob.elapsedTimeUnit = milliseconds
+
 ###################################
 ## V2 UI admin settings
 ###################################


### PR DESCRIPTION
grouper-ui.properties setting `uiV2.admin.daemonJob.elapsedTimeUnit = [milliseconds, seconds, minutes, h:m:s, hms]` will format the loader log columns for Millis, Millis get data, and Millis load data.