### PR TITLE
Add non-search LDAP referral support.

### DIFF
--- a/grouper-parent/pom.xml
+++ b/grouper-parent/pom.xml
@@ -163,7 +163,7 @@
         <p6spy.version>3.6.0</p6spy.version>
         <postgresql.version>42.7.2</postgresql.version>
         <mysql.connector.java.version>8.0.33</mysql.connector.java.version>
-        <ldaptive.version>2.3.1</ldaptive.version>
+        <ldaptive.version>2.4.0-SNAPSHOT</ldaptive.version>
         <unboundid.version>6.0.10</unboundid.version>
         <!-- if you change this version make sure container substitution still works -->
         <playwright.version>1.43.0</playwright.version>

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/LdapGrouperExternalSystem.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/LdapGrouperExternalSystem.java
@@ -107,7 +107,7 @@ public class LdapGrouperExternalSystem extends GrouperExternalSystem {
     String urlString = this.retrieveAttributes().get("url").getValue();
     if (!StringUtils.isBlank(urlString)) {
       LdapURL url = new LdapURL(urlString);
-      if (!url.isDefaultBaseDn()) {
+      if (!url.getUrl().isDefaultBaseDn()) {
         validationErrorsToDisplay.put(this.retrieveAttributes().get("url").getHtmlForElementIdHandle(), GrouperTextContainer.textOrNull("grouperConfigurationValidationLdapUrlContainsBaseDN"));
       }
     }

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/ldapProvisioning/LdapSyncCompare.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/ldapProvisioning/LdapSyncCompare.java
@@ -76,10 +76,10 @@ public class LdapSyncCompare extends GrouperProvisioningCompare {
       rdns = dn.getRDns();
     } else {
       rdns = new ArrayList<>();
-      List<RDn> remainingRdns = dn.getRDns();
+      List<RDn> remainingRdns = new ArrayList<>(dn.getRDns());
       Dn baseDn = new Dn(baseDnString);
       
-      while (remainingRdns.size() > 0) {
+      while (!remainingRdns.isEmpty()) {
         if (new Dn(remainingRdns).isSame(baseDn)) {
           // the rest is the base
           break;

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/LdapHandler.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/LdapHandler.java
@@ -24,10 +24,11 @@ package edu.internet2.middleware.grouper.ldap;
  * reference to the ldap session object
  * @version $Id: HibernateHandler.java,v 1.3 2009-02-06 16:33:18 mchyzer Exp $
  * @author mchyzer
- * @param <T> 
+ * @param <T>
+ * @param <R>
  */
 
-public interface LdapHandler<T> {
+public interface LdapHandler<T, R> {
 
   /**
    * This method will be called with the hibernate session object to do 
@@ -37,5 +38,5 @@ public interface LdapHandler<T> {
    * @return the return value to be passed to return value of callback method
    * @throws Exception 
    */
-  public Object callback(LdapHandlerBean<T> ldapHandlerBean) throws Exception;
+  R callback(LdapHandlerBean<T> ldapHandlerBean) throws Exception;
 }

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/GrouperRangeEntryHandler.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/GrouperRangeEntryHandler.java
@@ -40,9 +40,9 @@ public class GrouperRangeEntryHandler extends RangeEntryHandler {
         entry.setDn(dn);
 
         LdapURL ldapURL = getConnection().getLdapURL();
-        String baseDn = ldapURL != null ? ldapURL.getBaseDn() : null;
+        String baseDn = ldapURL != null ? ldapURL.getUrl().getBaseDn() : null;
         
-        if (!StringUtils.isBlank(baseDn) && !ldapURL.isDefaultBaseDn() && dn.toLowerCase().endsWith(baseDn.toLowerCase())) {
+        if (!StringUtils.isBlank(baseDn) && !ldapURL.getUrl().isDefaultBaseDn() && dn.toLowerCase().endsWith(baseDn.toLowerCase())) {
           String dnWithoutSuffix = dn.substring(0, dn.length() - baseDn.length());
           dnWithoutSuffix = dnWithoutSuffix.trim().replaceAll(",$", "");
           entry.setDn(dnWithoutSuffix);

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveConfiguration.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveConfiguration.java
@@ -75,7 +75,7 @@ final class LdaptiveConfiguration {
     String urlString = ldaptiveProperties.getProperty("org.ldaptive.ldapUrl");
     if (!StringUtils.isBlank(urlString)) {
       LdapURL url = new LdapURL(urlString);
-      if (!url.isDefaultBaseDn()) {
+      if (!url.getUrl().isDefaultBaseDn()) {
         throw new RuntimeException("Base DN not allowed to be configured in the ldap URL: " + urlString);
       }
     }

--- a/grouper/src/test/edu/internet2/middleware/grouper/app/ldapProvisioning/LdapProvisionerBushyTest.java
+++ b/grouper/src/test/edu/internet2/middleware/grouper/app/ldapProvisioning/LdapProvisionerBushyTest.java
@@ -457,7 +457,7 @@ public class LdapProvisionerBushyTest extends GrouperProvisioningBaseTest {
     assertEquals(1, ldapEntries.size());
     
     ldapEntry = LdapSessionUtils.ldapSession().list("personLdap", "cn=testGroup,ou=c,ou=b,ou=a,ou=testStemToMoveTo,ou=Groups,dc=example,dc=edu", LdapSearchScope.SUBTREE_SCOPE, "(objectClass=*)", new String[] {"objectClass", "cn", "member", "businessCategory", "description"}, null).get(0);
-    assertEquals("cn=testGroup,ou=c,ou=b,ou=a,ou=testStemToMoveTo,ou=Groups,dc=example,dc=edu", ldapEntry.getDn());
+    assertTrue("cn=testGroup,ou=c,ou=b,ou=a,ou=testStemToMoveTo,ou=Groups,dc=example,dc=edu".equalsIgnoreCase(ldapEntry.getDn()));
     assertEquals("testGroup", ldapEntry.getAttribute("cn").getStringValues().iterator().next());
     assertEquals(testGroup.getIdIndex().toString(), ldapEntry.getAttribute("businessCategory").getStringValues().iterator().next());
     assertEquals(2, ldapEntry.getAttribute("objectClass").getStringValues().size());

--- a/grouper/src/test/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImplTest.java
+++ b/grouper/src/test/edu/internet2/middleware/grouper/ldap/ldaptive/LdaptiveSessionImplTest.java
@@ -434,6 +434,21 @@ public class LdaptiveSessionImplTest {
   }
 
   @Test
+  public void addAndDeleteReferral() {
+    LdapEntry entry = new LdapEntry("uid=lsayer,ou=referral,dc=internet2,dc=edu");
+    entry.addAttribute(new LdapAttribute("objectclass", "inetOrgPerson"));
+    entry.addAttribute(new LdapAttribute("cn", "Leo Sayer"));
+    entry.addAttribute(new LdapAttribute("givenName", "Leo"));
+    entry.addAttribute(new LdapAttribute("sn", "Sayer"));
+    entry.addAttribute(new LdapAttribute("uid", "lsayer"));
+    entry.addAttribute(new LdapAttribute("uidNumber", "1006"));
+    entry.addAttribute(new LdapAttribute("mail", "lsayer@internet2.edu"));
+    entry.addAttribute(new LdapAttribute("telephoneNumber", "8169894347"));
+    session.create(SERVER_ID_REFERRAL, entry);
+    session.delete(SERVER_ID_REFERRAL, "uid=lsayer,ou=referral,dc=internet2,dc=edu");
+  }
+
+  @Test
   public void delete() {
     LdapEntry entry = new LdapEntry("uid=hmancini,ou=people,dc=internet2,dc=edu");
     entry.addAttribute(new LdapAttribute("objectclass", "inetOrgPerson"));


### PR DESCRIPTION
Update ldaptive to v2.4.0-SNAPSHOT
Add referral handlers for add, delete, modifyDn and modify operations. Improve LdapHandler interface generics to include the return type, which makes casting unnecessary. Improve memory usage by leveraging an entry handler to convert search entries to grouper domain objects.