### PR TITLE
Fix Duo provisioner to update 'realname' in Duo correctly

### DIFF
--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/duo/GrouperDuoApiCommands.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/duo/GrouperDuoApiCommands.java
@@ -52,9 +52,26 @@ public class GrouperDuoApiCommands {
     
 //    associateUserToGroup("duo1", "DUP0LW3MHLGSFMGGQAV3", "DGCXPKWT7MJ7WLQT7CMQ");
 //    disassociateUserFromGroup("duo1", "DUP0LW3MHLGSFMGGQAV3", "DGCXPKWT7MJ7WLQT7CMQ");
+
+    // GrouperDuoUser grouperDuoUserToUpdate = retrieveDuoUserByName("duo_user", "dz10025");
+    // grouperDuoUserToUpdate.setEmail("test1@dartmouth.edu");
+    // grouperDuoUserToUpdate.setRealName("Test1");
+    // System.out.println("grouperDuoUserToUpdate: "+grouperDuoUserToUpdate);
+
+    // Set<String> fieldsToUpdateOnUser = new HashSet<String>();
+    // fieldsToUpdateOnUser.add("name"); // known as 'realname' in duo api
+    // fieldsToUpdateOnUser.add("email");
     
+    // updateDuoUser("duo_user", grouperDuoUserToUpdate, fieldsToUpdateOnUser);
+
+    // GrouperDuoUser updatedDuoUser = retrieveDuoUserByName("duo_user", "dz10025");
+    // System.out.println("updatedDuoUser: "+updatedDuoUser);
+
+    // org.junit.Assert.assertEquals("Email not updated", grouperDuoUserToUpdate.getEmail(), updatedDuoUser.getEmail());
+    // org.junit.Assert.assertEquals("Real Name not updated", grouperDuoUserToUpdate.getRealName(), updatedDuoUser.getRealName());
+
     JsonNode jsonNode = retrieveDuoUserByNameJsonNode("duoAdminProdReadonly", "mchyzer", true);
-    
+
     System.out.println(jsonNode);
     
     System.exit(0);
@@ -806,7 +823,7 @@ public class GrouperDuoApiCommands {
         params.put("lastname", StringUtils.defaultString(grouperDuoUser.getLastName()));
       }
       
-      if (fieldsToUpdate == null || fieldsToUpdate.contains("realname")) {
+      if (fieldsToUpdate == null || fieldsToUpdate.contains("name")) {
         params.put("realname", StringUtils.defaultString(grouperDuoUser.getRealName()));
       }
       

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/duo/GrouperDuoApiCommands.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/duo/GrouperDuoApiCommands.java
@@ -52,26 +52,9 @@ public class GrouperDuoApiCommands {
     
 //    associateUserToGroup("duo1", "DUP0LW3MHLGSFMGGQAV3", "DGCXPKWT7MJ7WLQT7CMQ");
 //    disassociateUserFromGroup("duo1", "DUP0LW3MHLGSFMGGQAV3", "DGCXPKWT7MJ7WLQT7CMQ");
-
-    // GrouperDuoUser grouperDuoUserToUpdate = retrieveDuoUserByName("duo_user", "dz10025");
-    // grouperDuoUserToUpdate.setEmail("test1@dartmouth.edu");
-    // grouperDuoUserToUpdate.setRealName("Test1");
-    // System.out.println("grouperDuoUserToUpdate: "+grouperDuoUserToUpdate);
-
-    // Set<String> fieldsToUpdateOnUser = new HashSet<String>();
-    // fieldsToUpdateOnUser.add("name"); // known as 'realname' in duo api
-    // fieldsToUpdateOnUser.add("email");
     
-    // updateDuoUser("duo_user", grouperDuoUserToUpdate, fieldsToUpdateOnUser);
-
-    // GrouperDuoUser updatedDuoUser = retrieveDuoUserByName("duo_user", "dz10025");
-    // System.out.println("updatedDuoUser: "+updatedDuoUser);
-
-    // org.junit.Assert.assertEquals("Email not updated", grouperDuoUserToUpdate.getEmail(), updatedDuoUser.getEmail());
-    // org.junit.Assert.assertEquals("Real Name not updated", grouperDuoUserToUpdate.getRealName(), updatedDuoUser.getRealName());
-
     JsonNode jsonNode = retrieveDuoUserByNameJsonNode("duoAdminProdReadonly", "mchyzer", true);
-
+    
     System.out.println(jsonNode);
     
     System.exit(0);


### PR DESCRIPTION
If you configure a Duo provisioner to sync the 'realname' Duo attribute, for example:
```
provisioner.duo_user.targetEntityAttribute.3.name = name
provisioner.duo_user.targetEntityAttribute.3.translateExpressionType = grouperProvisioningEntityField
provisioner.duo_user.targetEntityAttribute.3.translateFromGrouperProvisioningEntityField = name
```

the provisioner will detect when the attribute is out of sync and attempt to update it, but the change will not be included the the HTTP post. This appears to be the same problem reported in slack by David Jardim https://internet2.slack.com/archives/C7V0UQDJ4/p1710523466936369

Problem is that `updateDuoUser` is looking at `fieldsToUpdate` to decide what fields to include in the update, and it needs to look for `name` instead of `realname`