### PR TITLE
GRP-6160: SQL provisioner membershipObjects should support row update

### DIFF
--- a/grouper/conf/grouper-loader.base.properties
+++ b/grouper/conf/grouper-loader.base.properties
@@ -4389,6 +4389,11 @@ grouper.provisioning.removeSyncLogRowsAfterDays = 7
 # {valueType: "string", order: 60001, required: true, showEl: "${operateOnGrouperEntities && numberOfEntityAttributes > $i$ && useSeparateTableForEntityAttributes}", formElement: "dropdown", optionValues: ["entityTableColumn", "separateAttributesTable"], repeatGroup: "targetEntityAttribute", repeatCount: 20}
 # provisioner.someSqlProvisioner.targetEntityAttribute.$i$.storageType =
 
+# Update memberships (only implemented for SQL provisioner membershipObjects)
+# {valueType: "boolean", order: 2510, indent: 1, defaultValue: "false", subSection: "membership", showEl: "${operateOnGrouperMemberships && (provisioningType == 'membershipObjects') && customizeMembershipCrud}"}
+# provisioner.someSqlProvisioner.updateMemberships =
+
+
 ########################################
 ## scim provisioner
 ########################################

--- a/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
@@ -15420,6 +15420,8 @@ config.GenericConfiguration.attribute.membershipFields.label = Membership fields
 config.GenericConfiguration.attribute.membershipFields.description = If provisioning normal memberships or privileges. Generally just leave this at the default (members which means memberships) unless you want the target to have information about who is allowed to perform certain operations in Grouper (e.g. READ memberships of a group)
 config.GenericConfiguration.attribute.insertMemberships.label = Insert memberships
 config.GenericConfiguration.attribute.insertMemberships.description = If memberships should be added to the target.  Generally this will be 'true'.
+config.GenericConfiguration.attribute.updateMemberships.label = Update memberships
+config.GenericConfiguration.attribute.updateMemberships.description = If memberships should be updated in the target.  This only applies if there are non-key fields in the membership table that are associated with the row.
 
 config.GenericConfiguration.attribute.replaceMemberships.label = Replace memberships
 config.GenericConfiguration.attribute.replaceMemberships.description = If memberships should be replaced in the target.  Generally this will be 'false'. This is only applicable if your provisioner can replace memberships.

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningCompare.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningCompare.java
@@ -518,8 +518,18 @@ public class GrouperProvisioningCompare {
     if (this.getGrouperProvisioner().retrieveGrouperProvisioningBehavior().getGrouperProvisioningBehaviorMembershipType() != null) {
       switch (this.getGrouperProvisioner().retrieveGrouperProvisioningBehavior().getGrouperProvisioningBehaviorMembershipType()) {
         case membershipObjects:
-          // we dont update any attribute for memberships, we just insert and delete them
-          return;
+          // if there are only keys to compare, we don't update, just insert and delete
+          if (
+            StringUtils.equals(attributeName, this.getGrouperProvisioner().retrieveGrouperProvisioningConfiguration().getMembershipEntityMatchingIdAttribute())
+            || StringUtils.equals(attributeName, this.getGrouperProvisioner().retrieveGrouperProvisioningConfiguration().getMembershipGroupMatchingIdAttribute())
+          ) {
+            return;
+          }
+
+          // don't need to compare non-key attributes only if we can't update
+          if (!this.getGrouperProvisioner().retrieveGrouperProvisioningConfiguration().isUpdateMemberships()) {
+            return;
+          }
         case entityAttributes:
           
           attributeForMemberships = this.getGrouperProvisioner().retrieveGrouperProvisioningConfiguration().getAttributeNameForMemberships();
@@ -1023,8 +1033,10 @@ public class GrouperProvisioningCompare {
       ProvisioningUpdatable targetProvisioningUpdatable, ProvisioningAttribute targetAttribute, String attributeName, 
       boolean recalc) {
 
-    // we dont update memberships right now
-    if (grouperProvisioningUpdatable instanceof ProvisioningMembership) {
+    // don't compare memberships unless we can update any changes
+    if (grouperProvisioningUpdatable instanceof ProvisioningMembership
+            && !((ProvisioningMembership)grouperProvisioningUpdatable).getProvisioningMembershipWrapper().getProvisioningStateMembership().isUpdate()
+            && !((ProvisioningMembership)grouperProvisioningUpdatable).getProvisioningMembershipWrapper().getProvisioningStateMembership().isRecalcObject()) {
       return;
     }
 
@@ -1074,6 +1086,11 @@ public class GrouperProvisioningCompare {
     
     // We're here because we're updating the membership attribute but we're not updating other attributes
     if (grouperProvisioningUpdatable instanceof ProvisioningGroup && !this.grouperProvisioner.retrieveGrouperProvisioningBehavior().isUpdateGroups()) {
+      return;
+    }
+
+    // We're here because we're updating the membership attribute but we're not updating other attributes
+    if (grouperProvisioningUpdatable instanceof ProvisioningMembership && !this.grouperProvisioner.retrieveGrouperProvisioningConfiguration().isUpdateMemberships()) {
       return;
     }
 

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningConfiguration.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningConfiguration.java
@@ -1688,6 +1688,22 @@ public abstract class GrouperProvisioningConfiguration {
   }
 
   /**
+   * if memberships should be updated in target
+   * @return
+   */
+  public boolean isUpdateMemberships() {
+    return updateMemberships;
+  }
+
+  /**
+   * if memberships should be updated in target
+   * @param updateMemberships
+   */
+  public void setUpdateMemberships(boolean updateMemberships) {
+    this.updateMemberships = updateMemberships;
+  }
+
+  /**
    * if memberships should be deleted in target
    * @return
    */
@@ -1960,7 +1976,13 @@ public abstract class GrouperProvisioningConfiguration {
    */
   private boolean insertMemberships = true;
 
-  
+
+  /**
+   * if memberships should be updated in target
+   */
+  private boolean updateMemberships = false;
+
+
   /**
    * if memberships should be deleted in target
    */
@@ -3040,7 +3062,9 @@ public abstract class GrouperProvisioningConfiguration {
     
     if (!this.operateOnGrouperMemberships) {
       this.insertMemberships = false;
-      
+
+      this.updateMemberships = false;
+
       this.deleteMemberships = false;
   
       this.selectMemberships = false;
@@ -3061,9 +3085,11 @@ public abstract class GrouperProvisioningConfiguration {
     
     this.customizeMembershipCrud = GrouperUtil.booleanValue(this.retrieveConfigBoolean("customizeMembershipCrud", false), false);
     if (this.customizeMembershipCrud) {
-      
+
       this.insertMemberships = GrouperUtil.booleanValue(this.retrieveConfigBoolean("insertMemberships", false), true);
-      
+
+      this.updateMemberships = GrouperUtil.booleanValue(this.retrieveConfigBoolean("updateMemberships", false), false);
+
       this.replaceMemberships = GrouperUtil.booleanValue(this.retrieveConfigBoolean("replaceMemberships", false), false);
 
       this.selectMemberships = GrouperUtil.booleanValue(this.retrieveConfigBoolean("selectMemberships", false), true);

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningConfigurationValidation.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/GrouperProvisioningConfigurationValidation.java
@@ -388,7 +388,10 @@ public class GrouperProvisioningConfigurationValidation {
 //      }
 //    }
     if (grouperProvisioningConfiguration.isOperateOnGrouperMemberships() && grouperProvisioningConfiguration.isCustomizeMembershipCrud()) {
-      if (!grouperProvisioningConfiguration.isSelectMemberships() && !grouperProvisioningConfiguration.isInsertMemberships() && !grouperProvisioningConfiguration.isReplaceMemberships()) {
+      if (!grouperProvisioningConfiguration.isSelectMemberships()
+              && !grouperProvisioningConfiguration.isInsertMemberships()
+              && !grouperProvisioningConfiguration.isUpdateMemberships()
+              && !grouperProvisioningConfiguration.isReplaceMemberships()) {
         this.addErrorMessage(new ProvisioningValidationIssue().assignMessage(GrouperTextContainer.textOrNull("provisioning.configuration.validation.mustSelectOrInsertMemberships")).assignJqueryHandle("operateOnGrouperMemberships"));
       }
     }
@@ -1318,7 +1321,7 @@ public class GrouperProvisioningConfigurationValidation {
     boolean operateOnGrouperMemberships = GrouperUtil.booleanValue(suffixToConfigValue.get("operateOnGrouperMemberships"), false);
     boolean customizeCrud = operateOnGrouperMemberships && GrouperUtil.booleanValue(suffixToConfigValue.get("customizeMembershipCrud"), false);
     boolean anythingSet = false;
-    for (String key : new String[] { "insertMemberships", "selectMemberships", "deleteMemberships", "deleteMembershipsIfNotExistInGrouper", 
+    for (String key : new String[] { "insertMemberships", "updateMemberships", "selectMemberships", "deleteMemberships", "deleteMembershipsIfNotExistInGrouper",
         "deleteMembershipsIfGrouperDeleted", "deleteMembershipsIfGrouperCreated", "deleteValueIfManagedByGrouper",
         "deleteMembershipsOnlyInTrackedGroups","deleteMembershipsIfGroupUnmarkedProvisionable"}) {
       if (!customizeCrud) {

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/ProvisioningStateBase.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/provisioning/ProvisioningStateBase.java
@@ -203,6 +203,10 @@ public class ProvisioningStateBase {
     if (this instanceof ProvisioningStateEntity) {
       return ((ProvisioningStateEntity)this).isRecalcEntityMemberships();
     }
+    if (this instanceof ProvisioningStateMembership) {
+      return ((ProvisioningStateMembership)this).isRecalcObject();
+    }
+
     throw new RuntimeException("Not expecting type: " + this.getClass().getName());
   }
 

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/sqlProvisioning/SqlProvisioningDao.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/sqlProvisioning/SqlProvisioningDao.java
@@ -2,12 +2,15 @@ package edu.internet2.middleware.grouper.app.sqlProvisioning;
 
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import edu.internet2.middleware.grouper.app.provisioning.targetDao.TargetDaoUpdateMembershipsRequest;
+import edu.internet2.middleware.grouper.app.provisioning.targetDao.TargetDaoUpdateMembershipsResponse;
 import org.apache.commons.lang.StringUtils;
 
 import edu.internet2.middleware.grouper.app.provisioning.GrouperProvisioner;
@@ -1281,7 +1284,74 @@ public class SqlProvisioningDao extends GrouperProvisionerTargetDaoBase {
     return new TargetDaoInsertMembershipsResponse();
     
   }
-  
+
+  @Override
+  public TargetDaoUpdateMembershipsResponse updateMemberships(TargetDaoUpdateMembershipsRequest targetDaoUpdateMembershipsRequest) {
+    List<ProvisioningMembership> targetMemberships = targetDaoUpdateMembershipsRequest.getTargetMemberships();
+
+    SqlProvisioningConfiguration sqlProvisioningConfiguration = (SqlProvisioningConfiguration) this.getGrouperProvisioner().retrieveGrouperProvisioningConfiguration();
+
+    String objectTableName = sqlProvisioningConfiguration.getMembershipTableName();
+
+
+    Map<String, GrouperProvisioningConfigurationAttribute> attributeNameToConfig = sqlProvisioningConfiguration.getTargetMembershipAttributeNameToConfig();
+
+    String sqlLastModifiedColumn = sqlProvisioningConfiguration.getSqlLastModifiedColumnName();
+    String sqlLastModifiedColumnType = sqlProvisioningConfiguration.getSqlLastModifiedColumnType();
+
+    for (ProvisioningMembership targetMembership: targetMemberships) {
+      List<String> columnsToUpdate = new ArrayList<>();
+      List<Object> oldValuesToUpdate = new ArrayList<>();
+      List<Object> newValuesToUpdate = new ArrayList<>();
+
+      List<String> whereClauseColumns = new ArrayList<>();
+      List<Object> whereClauseValues = new ArrayList<>();
+
+      for (ProvisioningObjectChange objectChange: targetMembership.getInternal_objectChanges()) {
+        columnsToUpdate.add(objectChange.getAttributeName());
+        oldValuesToUpdate.add(objectChange.getOldValue());
+        newValuesToUpdate.add(objectChange.getNewValue());
+      }
+
+      if (StringUtils.isNotBlank(sqlLastModifiedColumn)) {
+        if (StringUtils.equals("long", sqlLastModifiedColumnType)) {
+          columnsToUpdate.add(sqlLastModifiedColumn);
+          oldValuesToUpdate.add(null);
+          newValuesToUpdate.add(lastModified());
+        } else if (StringUtils.equals("timestamp", sqlLastModifiedColumnType)) {
+          columnsToUpdate.add(sqlLastModifiedColumn);
+          oldValuesToUpdate.add(null);
+          newValuesToUpdate.add(new Timestamp(lastModified()));
+        } else {
+          throw new RuntimeException("Invalid sqlLastModifiedColumnType: '"+sqlLastModifiedColumnType+"'");
+        }
+      }
+
+      /* add match on the primary keys */
+      whereClauseColumns.add(sqlProvisioningConfiguration.getMembershipGroupMatchingIdAttribute());
+      whereClauseValues.add(targetMembership.retrieveAttributeValue(sqlProvisioningConfiguration.getMembershipGroupMatchingIdAttribute()));
+
+      whereClauseColumns.add(sqlProvisioningConfiguration.getMembershipEntityMatchingIdAttribute());
+      whereClauseValues.add(targetMembership.retrieveAttributeValue(sqlProvisioningConfiguration.getMembershipEntityMatchingIdAttribute()));
+
+      /* perform the update */
+      SqlProvisionerCommands.updateObjects(sqlProvisioningConfiguration.getDbExternalSystemConfigId(),
+              objectTableName,
+              columnsToUpdate,
+              Collections.singletonList(newValuesToUpdate.toArray()),
+              whereClauseColumns,
+              Collections.singletonList(whereClauseValues.toArray())
+      );
+
+      targetMembership.setProvisioned(true);
+      for (ProvisioningObjectChange provisioningObjectChange : GrouperUtil.nonNull(targetMembership.getInternal_objectChanges())) {
+        provisioningObjectChange.setProvisioned(true);
+      }
+    }
+
+    return new TargetDaoUpdateMembershipsResponse();
+  }
+
   /**
    * 
    */
@@ -2337,7 +2407,8 @@ public class SqlProvisioningDao extends GrouperProvisionerTargetDaoBase {
 
     grouperProvisionerDaoCapabilities.setCanUpdateGroups(true);
     grouperProvisionerDaoCapabilities.setCanUpdateEntities(true);
-    
+    grouperProvisionerDaoCapabilities.setCanUpdateMemberships(true);
+
     if (this.getGrouperProvisioner().retrieveGrouperProvisioningBehavior().getGrouperProvisioningBehaviorMembershipType() == GrouperProvisioningBehaviorMembershipType.groupAttributes) {
       grouperProvisionerDaoCapabilities.setCanRetrieveMembershipsWithGroup(true);
       grouperProvisionerDaoCapabilities.setCanRetrieveMembershipsSomeByGroups(true);
@@ -2354,6 +2425,5 @@ public class SqlProvisioningDao extends GrouperProvisionerTargetDaoBase {
       grouperProvisionerDaoCapabilities.setCanRetrieveMembershipsAllByGroups(true);
       grouperProvisionerDaoCapabilities.setCanRetrieveMembershipsAllByEntities(true);
     }
-    
   }
 }


### PR DESCRIPTION
https://todos.internet2.edu/browse/GRP-6160

This is only implemented for the SQL membershipObjects with customized CRUD, so the only time the option Update Memberships shows up. It's been tested with various provisioners:

- membershipTable
- groupTableMembershipTable
- entityTableWithAttributeTableAndMemberships (updates were already working in the attribute table)
- groupTableWithAttributeTableAndMemberships (updates were already working in the attribute table)

I haven't tested it yet with lastUpdated and delete columns.