### PR TITLE
fix: french text for quartzCron example was wrong

### DIFF
--- a/grouper/conf/grouperText/grouper.textNg.fr.fr.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.fr.fr.base.properties
@@ -1057,7 +1057,7 @@ tooltipTargetted.groupFields.grouperLoaderIntervalSeconds=S'il s'agit d'un type 
 # filter in log screen
 grouperLoaderLogsFilterFor=Filtrer par :
 tooltipTargetted.groupFields.grouperLoaderPriority=Le loader peut exécuter un nombre maximum de travaux simultanément, et quand ce maximum est atteint, alors les travaux sont priorisés par cette valeur (du plus grand au plus petit). La valeur par défaut est 5.
-tooltipTargetted.groupFields.grouperLoaderQuartzCron=Planification à la "CRON" (Quartz Scheduler) : Secondes Minutes Heures Jour du mois Mois Jour de la semaine Année (champ facultatif)<br />par ex. 0 0 6 * * ? : chaque jour à 6 heures<br />30 8-18/4 * * 1-5 ? : du lundi au vendredi de 8h30 à 18h30, toutes les 4 heures (donc 8h30, 12h30, 16h30)
+tooltipTargetted.groupFields.grouperLoaderQuartzCron=Planification à la "CRON" (Quartz Scheduler) : Secondes Minutes Heures Jour du mois Mois Jour de la semaine Année (champ facultatif)<br />par ex. 0 0 6 * * ? : chaque jour à 6 heures<br />0 30 8-18/4 ? * MON-FRI : du lundi au vendredi de 8h30 à 18h30, toutes les 4 heures (donc 8h30, 12h30, 16h30)
 tooltipTargetted.groupFields.grouperLoaderQuery=Requête à lancer sur la base de données. Si c'est une requête SQL_SIMPLE, elle doit retourner les colonnes SUBJECT_ID (obligatoire) et SUBJECT_SOURCE_ID (facultative)
 tooltipTargetted.groupFields.grouperLoaderScheduleType=CRON: syntaxe spécifique à quartz START_TO_START_INTERVAL: délai en secondes entre deux lancements
 tooltipTargetted.groupFields.grouperLoaderType=SQL_SIMPLE: groupe dont les membres sont le résultat d'une requête\nSQL_GROUP_LIST: la colonne GROUP_NAME est obligatoire, de telle façon que la requête peut contrôler les multi-appartenances
@@ -9915,7 +9915,7 @@ grouperReportConfigNameHint=Nom du rapport. Un utilisateur ne doit pas avoir deu
 grouperReportConfigFileNameHint=Nom du fichier. $$timestamp$$ est une variable contenant l'heure actuelle dans le format : aaaa_mm_jj_hh24_mi_ss. Exemple : usersOfMyService_$$timestamp$$.csv
 grouperReportConfigDescriptionHint=Description du rapport.
 grouperReportConfigViewersGroupIdHint=Les personnes appartenant à ce groupe pourront voir le rapport. Laisser à vide pour donner l'accès qu'aux administrateurs.
-grouperReportConfigQuartzCronHint=Planification à la "CRON" (Quartz Scheduler) : Secondes Minutes Heures Jour du mois Mois Jour de la semaine Année (champ facultatif)<br />par ex. 0 0 6 * * ? : chaque jour à 6 heures<br />30 8-18/4 * * 1-5 ? : du lundi au vendredi de 8h30 à 18h30, toutes les 4 heures (donc 8h30, 12h30, 16h30)
+grouperReportConfigQuartzCronHint=Planification à la "CRON" (Quartz Scheduler) : Secondes Minutes Heures Jour du mois Mois Jour de la semaine Année (champ facultatif)<br />par ex. 0 0 6 * * ? : chaque jour à 6 heures<br />0 30 8-18/4 ? * MON-FRI : du lundi au vendredi de 8h30 à 18h30, toutes les 4 heures (donc 8h30, 12h30, 16h30)
 grouperReportConfigSendEmailHint=Si un courriel doit être envoyé lorsque le rapport est prêt
 grouperReportConfigEmailSubjectHint=sujet du courriel (facultatif, sera généré à partir du nom du rapport s'il est vide)
 grouperReportConfigEmailBodyHint=facultatif, sera généré par défaut s'il est vide. Supporte les retours à la ligne. Les variables suivantes peuvent être utilisées : $$reportConfigName$$, $$reportConfigDescription$$, $$subjectName$$ et $$reportLink$$. La variable $$reportLink$$ contient le lien vers la page du rapport.


### PR DESCRIPTION
NB: english text does not have this complex example. Add it to english too or remove from french?