### PR TITLE
Fix for config entry rename bug.

### DIFF
--- a/grouper-misc/grouper-ext-auth/src/main/java/edu/internet2/middleware/grouper/authentication/plugin/ConfigUtils.java
+++ b/grouper-misc/grouper-ext-auth/src/main/java/edu/internet2/middleware/grouper/authentication/plugin/ConfigUtils.java
@@ -76,7 +76,7 @@ public class ConfigUtils {
                 .toList()) {
             // map name to realname if needed (e.g., changing case)
             String realName = ConfigUtils.propertyNameRename(name);
-            String fieldName = realName.substring(name.lastIndexOf('.') + 1);
+            String fieldName = realName.substring(realName.lastIndexOf('.') + 1);
             try {
                 Method method = getSetter(clazz, getMethodNameFromFieldName(fieldName));
                 method.invoke(configuration, getProperty(grouperConfig, method.getParameterTypes()[0], name));
@@ -108,7 +108,12 @@ public class ConfigUtils {
      * @return
      */
     private static String propertyNameRename(String propertyName) {
-        return PROPERTY_RENAMES.getOrDefault(propertyName, propertyName);
+        for (Map.Entry<String, String> rename: PROPERTY_RENAMES.entrySet()) {
+            if(rename.getValue() != null && rename.getValue().equals(propertyName)) {
+                return rename.getKey();
+            }
+        }
+        return propertyName;
     }
 
     private static String getMethodNameFromFieldName(String fieldName) {


### PR DESCRIPTION
As far as I can tell this code was not going to work with PAC4J 6.  The setter for these two configuration entries could not be found because the hashmap lookup was trying to find something that was in the VALUE, not the key.  I have testing this fix in our install, it works for us!

Additionally line 79 worked, but would cause issues if any entries were ever added to the hashmap that had differing lengths between key/value.