### PR TITLE
Add support for client_secret_basic authentication in OIDC client credentials flow

### DIFF
--- a/grouper/conf/grouper-loader.base.properties
+++ b/grouper/conf/grouper-loader.base.properties
@@ -5053,6 +5053,10 @@ teamDynamixAuthnTokenExpiresSeconds = 60
 # {valueType: "boolean", defaultValue: "true", regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.sendParametersInBody$", showEl: "${httpAuthnType == 'oauthClientCredentials'}"}
 # grouper.wsBearerToken.myWsBearerToken.sendParametersInBody =
 
+# Send client credentials in Basic auth header
+# {valueType: "boolean", defaultValue: "false", regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.sendClientAuthorizationBasicHttpHeader$", showEl: "${sendParametersInBody}"}
+# grouper.wsBearerToken.myWsBearerToken.sendClientAuthorizationBasicHttpHeader =
+
 # Api key header name
 # {valueType: "string", regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.apiKeyHeaderName$", showEl: "${httpAuthnType == 'oauthClientCredentials'}"}
 # grouper.wsBearerToken.myWsBearerToken.apiKeyHeaderName =

--- a/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
@@ -13727,6 +13727,9 @@ config.WsBearerTokenExternalSystem.attribute.apiKeyHeaderName.label = API key he
 config.WsBearerTokenExternalSystem.attribute.sendParametersInBody.label = Send parameters in body
 config.WsBearerTokenExternalSystem.attribute.sendParametersInBody.description = If the parameters should be sent in the body instead of the URL
 
+config.WsBearerTokenExternalSystem.attribute.sendClientAuthorizationBasicHttpHeader = Send client credentials in Basic auth header
+config.WsBearerTokenExternalSystem.attribute.sendClientAuthorizationBasicHttpHeader.description = If the Authorization header should be sent as base64. Authorization: Basic <base64(client_id:client_secret)>
+
 config.WsBearerTokenExternalSystem.attribute.apiKeyPassword.label = API key password
 
 config.WsBearerTokenExternalSystem.attribute.clientCredentialType.label = Client credential type

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/WsBearerTokenExternalSystem.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/WsBearerTokenExternalSystem.java
@@ -246,7 +246,15 @@ public class WsBearerTokenExternalSystem extends GrouperExternalSystem {
         if (StringUtils.isNotBlank(scope)) {
           grouperHttpClient.addBodyParameter("scope", scope);
         }
-        
+
+        if (GrouperLoaderConfig.retrieveConfig().propertyValueBoolean(
+                "grouper.wsBearerToken." + configId + ".sendClientAuthorizationBasicHttpHeader", true)) {
+          // client_secret_basic : Authorization: Basic <base64(client_id:client_secret)>
+          final String secret = GrouperLoaderConfig.retrieveConfig().propertyValueStringRequired("grouper.wsBearerToken." + configId + ".clientSecret");
+          grouperHttpClient.assignUser(clientId);
+          grouperHttpClient.assignPassword(secret);
+        }
+
       } else {
         grouperHttpClient.addUrlParameter("grant_type", grantType);
         grouperHttpClient.addUrlParameter("client_id", clientId);


### PR DESCRIPTION
Some identity providers recommend or require the use of the client_secret_basic authentication method when retrieving a bearer token via the OIDC client credentials flow. Until now, Grouper supported client_secret_post, which passes the client_id and client_secret as body parameters.

This change adds a new boolean configuration property, sendClientAuthorizationBasicHttpHeader, on the WsBearerToken external system. When enabled, Grouper sends the client credentials as an HTTP Basic Authorization header (Authorization: Basic <base64(client_id:client_secret)>), as described in the OIDC Core specification (https://openid.net/specs/openid-connect-core-1_0.html#ClientAuthentication).

Changes included:
- New property sendClientAuthorizationBasicHttpHeader in grouper-loader.base.properties
- Corresponding label and description in grouper.textNg.en.us.base.properties
- Logic in WsBearerTokenExternalSystem.java to set HTTP Basic credentials when the property is enabled

This improves compatibility with identity providers that do not accept credentials in the request body.