### PR TITLE
Merge serviceUrl and endpoint parameters in WsBearerTokenExternalSystem

### DIFF
--- a/grouper/conf/grouper-loader.base.properties
+++ b/grouper/conf/grouper-loader.base.properties
@@ -5009,17 +5009,13 @@ teamDynamixAuthnTokenExpiresSeconds = 60
 # {valueType: "string", defaultValue: "bearerToken", regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.httpAuthnType$", formElement: "dropdown", optionValues: ["bearerToken", "basicAuth", "oauthClientCredentials"]}
 # grouper.wsBearerToken.myWsBearerToken.httpAuthnType = 
 
-# Base website URL for WS with bearer token authn.  e.g. https://scim.us-east-1.amazonaws.com/abc123/scim/v2/
-# {valueType: "string", required: true, regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.endpoint$", showEl: "${httpAuthnType == 'bearerToken' || httpAuthnType == 'basicAuth'}"}
+# Base website URL for WS e.g. https://scim.us-east-1.amazonaws.com/abc123/scim/v2/
+# {valueType: "string", required: true, regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.endpoint$"}
 # grouper.wsBearerToken.myWsBearerToken.endpoint = 
 
 # Token URL
 # {valueType: "string", required: true, regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.tokenUrl$", showEl: "${httpAuthnType == 'oauthClientCredentials'}"}
 # grouper.wsBearerToken.myWsBearerToken.tokenUrl = 
-
-# Service URL
-# {valueType: "string", required: true, regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.serviceUrl$", showEl: "${httpAuthnType == 'oauthClientCredentials'}"}
-# grouper.wsBearerToken.myWsBearerToken.serviceUrl = 
 
 # Client id
 # {valueType: "string", required: true, regex: "^grouper\\.myWsBearerToken\\.([^.]+)\\.clientId$", showEl: "${httpAuthnType == 'oauthClientCredentials'}"}

--- a/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
@@ -13717,7 +13717,6 @@ config.WsBearerTokenExternalSystem.attribute.testHttpResponseCode.label = Test H
 config.WsBearerTokenExternalSystem.attribute.testUrlResponseBodyRegex.label = Test response body regex
 
 config.WsBearerTokenExternalSystem.attribute.tokenUrl.label = Token URL
-config.WsBearerTokenExternalSystem.attribute.serviceUrl.label = Service URL
 config.WsBearerTokenExternalSystem.attribute.clientId.label = Client id
 config.WsBearerTokenExternalSystem.attribute.clientSecret.label = Client secret
 config.WsBearerTokenExternalSystem.attribute.grantType.label = Grant type

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/adobe/GrouperAdobeApiCommands.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/adobe/GrouperAdobeApiCommands.java
@@ -99,7 +99,7 @@ public class GrouperAdobeApiCommands {
 
     WsBearerTokenExternalSystem.attachAuthenticationToHttpClient(grouperHttpCall, configId, grouperLoaderConfig, debugMap);
 
-    String url = grouperLoaderConfig.propertyValueStringRequired("grouper.wsBearerToken." + configId + ".serviceUrl");
+    String url = grouperLoaderConfig.propertyValueStringRequired("grouper.wsBearerToken." + configId + ".endpoint");
 
     if (url.endsWith("/")) {
       url = url.substring(0, url.length() - 1);

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/WsBearerTokenExternalSystem.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/externalSystem/WsBearerTokenExternalSystem.java
@@ -464,11 +464,7 @@ public class WsBearerTokenExternalSystem extends GrouperExternalSystem {
     GrouperLoaderConfig config = GrouperLoaderConfig.retrieveConfig();
     String configPrefix = "grouper.wsBearerToken." + this.getConfigId() + ".";
 
-    String httpAuthnType = config
-        .propertyValueString(
-            configPrefix + "httpAuthnType", "bearerToken");
-
-    String endpointProperty = configPrefix + (StringUtils.equals("oauthClientCredentials", httpAuthnType) ? "serviceUrl" : "endpoint");
+    String endpointProperty = configPrefix + "endpoint";
     String endpoint = config.propertyValueString(endpointProperty);
     if (GrouperUtil.isBlank(endpoint)) {
       ret.add("Undefined or blank property: " + endpointProperty);

--- a/grouper/src/grouper/edu/internet2/middleware/grouper/app/okta/GrouperOktaApiCommands.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/app/okta/GrouperOktaApiCommands.java
@@ -58,7 +58,7 @@ public class GrouperOktaApiCommands {
       
       GrouperLoaderConfig grouperLoaderConfig = GrouperLoaderConfig.retrieveConfig();
       
-      String tenantDomain = grouperLoaderConfig.propertyValueStringRequired("grouper.wsBearerToken." + configId + ".serviceUrl");
+      String tenantDomain = grouperLoaderConfig.propertyValueStringRequired("grouper.wsBearerToken." + configId + ".endpoint");
 
       WsBearerTokenExternalSystem.attachAuthenticationToHttpClient(grouperHttpCall, configId, grouperLoaderConfig, debugMap);
 

--- a/grouper/src/test/edu/internet2/middleware/grouper/app/adobe/AdobeProvisionerTestUtils.java
+++ b/grouper/src/test/edu/internet2/middleware/grouper/app/adobe/AdobeProvisionerTestUtils.java
@@ -34,7 +34,7 @@ public class AdobeProvisionerTestUtils {
       
     } else {
       new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.tokenUrl").value(ssl ? "https://": "http://" +  domainName+":"+port+"/grouper/mockServices/adobe/token/").store();
-      new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.serviceUrl").value(ssl ? "https://": "http://" +  domainName+":"+port+"/grouper/mockServices/adobe/").store();
+      new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.endpoint").value(ssl ? "https://": "http://" +  domainName+":"+port+"/grouper/mockServices/adobe/").store();
       new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.scopes").value("openid,AdobeID,user_management_sdk").store();
       new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.httpAuthnType").value("oauthClientCredentials").store();
       new GrouperDbConfig().configFileName("grouper-loader.properties").propertyName("grouper.wsBearerToken.adobe.grantType").value("client_credentials").store();


### PR DESCRIPTION
### Context

Since commit cdbc1b730 `WsBearerTokenExternalSystem` exposes two URL parameters:
- `serviceUrl` — intended for OAuth client credentials flows
- `endpoint` — intended for other use cases

In practice, these two parameters serve very similar purposes, which creates confusion and maintenance overhead.

### Problem

Some provisioners (e.g. `GrouperScim2Provisioner`) rely on `endpoint` to determine the target URL, but the property cannot be populated with an OAuth client credentials flow, leading to a runtime error like (full trace below):

```
java.lang.RuntimeException: Can't find property: grouper.wsBearerToken.<configId>.endpoint
  in properties file: grouper-loader.properties, it is required
```

This was observed when using a **Gravitee SCIM API** configuration (with authenticationtype as 'oauth client credentials'), even though `serviceUrl` was correctly set.

### Proposal

Unify the two parameters by deprecating `serviceUrl` in favour of `endpoint`, which appears to be the more consistently used one across provisioners. This avoids the ambiguity of having two nearly identical URL fields and prevents runtime failures when a provisioner expects `endpoint` but only `serviceUrl` is configured.


### Full Trace 

```
provisionerClass: GrouperScim2Provisioner, configId: sandbox-api-amue-identite, provisioningType: fullProvisionFull, instanceId: wykao35y, state: retrieveAllDataFromGrouperAndTarget, retrieveSyncGroupsMillis: 4, syncGroupCount: 1, retrieveSyncEntitiesMillis: 2, syncEntityCount: 2, retrieveSyncMshipsMillis: 1, syncMshipCount: 2, propagateProvisioningAttributes_millis: 102, targetRetrieveAllGroups: 1, exception: java.lang.RuntimeException: Cant find property: grouper.wsBearerToken.sandbox-api-amue.endpoint in properties file: grouper-loader.properties, it is required
	at edu.internet2.middleware.grouperClient.config.ConfigPropertiesCascadeBase.propertyValueStringHelper(ConfigPropertiesCascadeBase.java:569)
	at edu.internet2.middleware.grouperClient.config.ConfigPropertiesCascadeBase.propertyValueString(ConfigPropertiesCascadeBase.java:517)
	at edu.internet2.middleware.grouperClient.config.ConfigPropertiesCascadeBase.propertyValueStringRequired(ConfigPropertiesCascadeBase.java:422)
	at edu.internet2.middleware.grouper.app.scim2Provisioning.GrouperScim2ApiCommands.httpMethod(GrouperScim2ApiCommands.java:839)
	at edu.internet2.middleware.grouper.app.scim2Provisioning.GrouperScim2ApiCommands.executeMethod(GrouperScim2ApiCommands.java:901)
	at edu.internet2.middleware.grouper.app.scim2Provisioning.GrouperScim2ApiCommands.retrieveScimGroups(GrouperScim2ApiCommands.java:1915)
	at edu.internet2.middleware.grouper.app.scim2Provisioning.GrouperScim2TargetDao.retrieveAllGroups(GrouperScim2TargetDao.java:91)
...
```

Thank you.