### PR TITLE
Fix CSRF token bypass when pressing Enter on GSH template forms

### DIFF
--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupNewTemplate.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupNewTemplate.jsp
@@ -1,7 +1,7 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
 
 
-<form id="newGroupTemplateFormId" class="form-horizontal" method="post" action="UiV2Template.customTemplateExecute" enctype = "multipart/form-data">
+<form id="newGroupTemplateFormId" class="form-horizontal" method="post" action="UiV2Template.customTemplateExecute" enctype="multipart/form-data" onsubmit="return false;" onkeydown="if(event.key==='Enter' && event.target.tagName.toLowerCase() !== 'textarea'){if($('#newGroupTemplateFormId a.btn-primary').length){guiSubmitFileForm(event, '#newGroupTemplateFormId', '../app/UiV2Template.customTemplateExecute');}}">
   <input type="hidden" name="groupId" value="${grouperRequestContainer.groupContainer.guiGroup.group.id}" />
 
   <grouper:browserPage jspName="newTemplate" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemNewTemplate.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemNewTemplate.jsp
@@ -3,7 +3,7 @@
 
 <c:choose>
   <c:when test="${grouperRequestContainer.groupStemTemplateContainer.guiGshTemplateConfig != null}">
-    <form id="newStemTemplateFormId" class="form-horizontal" method="post" action="UiV2Template.customTemplateExecute" enctype = "multipart/form-data">
+    <form id="newStemTemplateFormId" class="form-horizontal" method="post" action="UiV2Template.customTemplateExecute" enctype="multipart/form-data" onsubmit="return false;" onkeydown="if(event.key==='Enter' && event.target.tagName.toLowerCase() !== 'textarea'){if($('#newStemTemplateFormId a.btn-primary').length){guiSubmitFileForm(event, '#newStemTemplateFormId', '../app/UiV2Template.customTemplateExecute');}}">
   </c:when>
   <c:otherwise>
     <form id="newStemTemplateFormId" class="form-horizontal">


### PR DESCRIPTION
Fixes [GRP-6947](https://todos.internet2.edu/browse/GRP-6947)

Pressing Enter in a text field on `groupNewTemplate.jsp` or `stemNewTemplate.jsp` triggers a native browser form POST, bypassing the OWASP CSRF token that `guiSubmitFileForm()` injects. Result: a full-page CSRF error instead of the template executing.

**Fix:** add `onsubmit="return false;"` to block native submission, and an `onkeydown` handler that intercepts Enter and routes it through `guiSubmitFileForm()` — the same CSRF-aware path used by the submit button. Textarea elements are excluded so multi-line inputs continue to work normally.

Tested on Grouper 6.1.1 quickstart container.