### PR TITLE
Fix for the ldapConvertLDAPMemberDnToSubjectIdOrGroup method

### DIFF
--- a/grouper/src/grouper/edu/internet2/middleware/grouper/util/GrouperUtil.java
+++ b/grouper/src/grouper/edu/internet2/middleware/grouper/util/GrouperUtil.java
@@ -2317,14 +2317,12 @@ public class GrouperUtil {
       LOG.debug("Start conversion of DN '" + dn + "'");
     }
   
-    // get the domain suffix, RDN attribute and RDN value from the DN
-    String domainSuffix = dn.substring(dn.toLowerCase().indexOf("dc="));
+    // get the RDN attribute and RDN value from the DN
     String rdnAttribute = StringUtils.substringBefore(dn,"=");
-    String rdnValue = ldapConvertDnToSpecificValue(dn);
+    String rdnValue = FilterUtils.escape(ldapConvertDnToSpecificValue(dn));
     
-    // searchBase is member DN minus suffix (domainSuffix) minus trailing comma
-    // This has to be done since LdapSession.list appends LDAP suffix to search base values
-    String searchBase = StringUtils.chop(StringUtils.removeEnd(dn.toLowerCase(),domainSuffix.toLowerCase()));
+    // searchBase is member DN 
+    String searchBase = dn;
     
     // Forward slash is a special character in JNDI. In case the dn contains one, this addresses it.
     // This may no longer be needed with patched versions of grouper. 
@@ -2374,7 +2372,7 @@ public class GrouperUtil {
       // Check that the member object is within the baseOu space
       if ( dn.toLowerCase().indexOf(baseOu.toLowerCase()) > 0 ) {
         // convert the DN to a grouper group
-        String groupName = convertDnToGroupName(dn, domainSuffix, grouperBaseStem); 
+        String groupName = ldapConvertDnToGroupName(dn, baseOu, grouperBaseStem);
       
         // see if the group exists
         Group group = GrouperDAOFactory.getFactory().getGroup().findByName(groupName, false, null) ;


### PR DESCRIPTION
- Previously the domain suffix was chopped off because the LDAP URL allowed for the base DN to be specified, e.g: ldaps://ldap.example.edu/dc=example,dc=edu. This is no longer supported so the baseDN is now the DN of the group members. 
- Used FilterUtils.escape to escape special characters in ldap search filter and account for special characters such as paranthesis in the object names