### PR TITLE
GRP-7066: Accessibility: Add labels to form controls flagged by WAVE "Missing form label"

### DIFF
--- a/grouper-ui/java/src/edu/internet2/middleware/grouper/ui/tags/ConfigFormElement.java
+++ b/grouper-ui/java/src/edu/internet2/middleware/grouper/ui/tags/ConfigFormElement.java
@@ -373,12 +373,13 @@ public class ConfigFormElement extends SimpleTagSupport {
       if (!readOnly) {
         field.append("<input class='config-el-checkbox' type='checkbox' ");
         field.append("name='config_el_"+configId+"' ");
+        field.append("aria-label='" + GrouperUtil.xmlEscape(GrouperTextContainer.textOrNull("grouperConfigIsElLabel")) + "' ");
         
         if (hasExpressionLanguage) {
           field.append(" checked ");
         }
             
-        field.append("onchange=\""+ajaxCallback+"\"");
+        field.append("onchange=\""+ajaxCallback+"\">");
         field.append("</input><span rel='tooltip' class='config-el-label' title='" + GrouperUtil.xmlEscape(GrouperTextContainer.textOrNull("grouperConfigIsElTooltip")) + "'>");
         field.append(GrouperTextContainer.textOrNull("grouperConfigIsElLabel"));
         field.append("</span>");
@@ -400,11 +401,15 @@ public class ConfigFormElement extends SimpleTagSupport {
       
       displayClass = " display: none; ";
     }
-    
+
+    // when read-only the label above is not rendered, so give the (hidden) control its own accessible name
+    String readOnlyAriaLabel = (readOnly && StringUtils.isNotBlank(label)) ? " aria-label='" + GrouperUtil.xmlEscape(label) + "' " : "";
+
     if (configItemFormElement == ConfigItemFormElement.TEXT) {
       
       field.append(
           "<input data-gr-input-type='text' style='width:30em; "+ displayClass + "' type='text' id='config_"+configId+"_id' name='config_" + configId + "'");
+      field.append(readOnlyAriaLabel);
       if (value != null) {
         field.append(" value = '"+GrouperUtil.escapeHtml(value, true)+"'");
       }
@@ -415,7 +420,7 @@ public class ConfigFormElement extends SimpleTagSupport {
     if (configItemFormElement == ConfigItemFormElement.TEXTAREA) {
             
       field.append("<textarea data-gr-input-type='textarea' style='width:30em; "+ displayClass + "' cols='20' rows='3' id='config_"+configId+"_id' name='config_"
-          + configId + "'>");
+          + configId + "'" + readOnlyAriaLabel + ">");
       if (value != null) {
         field.append(GrouperUtil.escapeHtml(value, true));
       }
@@ -426,7 +431,7 @@ public class ConfigFormElement extends SimpleTagSupport {
     if (configItemFormElement == ConfigItemFormElement.FILE) {
       
       field.append("<input type='file' data-gr-input-type='file' style='width:30em; "+ displayClass + "' cols='20' rows='3' id='config_"+configId+"_id' name='config_"
-          + configId + "'>");
+          + configId + "'" + readOnlyAriaLabel + ">");
       if (value != null) {
         field.append(GrouperUtil.escapeHtml(value, true));
       }
@@ -437,6 +442,7 @@ public class ConfigFormElement extends SimpleTagSupport {
       
       field.append(
           "<input style='width:30em; "+ displayClass + "' data-gr-input-type='password' type='password' id='config_"+configId+"_id' name= 'config_" + configId + "'");
+      field.append(readOnlyAriaLabel);
       if (value != null) {
         field.append(" value = '"+GrouperUtil.escapeHtml(value, true)+"'");
       }
@@ -508,7 +514,8 @@ public class ConfigFormElement extends SimpleTagSupport {
           String radioButtonValue = GrouperUtil.stringValue(multiKey.getKey(1));
           boolean checked = StringUtils.equals(key, value);
 
-          field.append("<input type='radio' class='config-radio-button'"+ displayClass+"' id='config_"+configId+(index==0?"":Integer.toString(index))+"_id' name='config_"+configId+"' value='"+key+"' ");
+          field.append("<input type='radio' class='config-radio-button' style='"+ displayClass+"' id='config_"+configId+(index==0?"":Integer.toString(index))+"_id' name='config_"+configId+"' value='"+key+"' ");
+          field.append("aria-label='"+GrouperUtil.xmlEscape(radioButtonValue)+"' ");
           field.append(checked ? " checked ": "");
           field.append("onchange=\""+ajaxCallback+"\"");
           field.append(">");
@@ -555,7 +562,7 @@ public class ConfigFormElement extends SimpleTagSupport {
         }
         
         field.append("></input>");
-        field.append("&nbsp; &nbsp; <label for '"+GrouperUtil.escapeHtml(value, true)+"_id'>");
+        field.append("&nbsp; &nbsp; <label for='"+GrouperUtil.escapeHtml(value, true)+"_id'>");
         field.append(label);
         field.append("</label>");
         field.append("<br>");

--- a/grouper-ui/java/src/edu/internet2/middleware/grouper/ui/tags/GrouperAbbreviateTextareaTag.java
+++ b/grouper-ui/java/src/edu/internet2/middleware/grouper/ui/tags/GrouperAbbreviateTextareaTag.java
@@ -183,8 +183,9 @@ public class GrouperAbbreviateTextareaTag extends SimpleTagSupport {
     result.append(" <a href=\"$\" onclick=\"$('#grouperAbbreviateTextarea__" + uniqueId + "').show('slow'); $('#grouperAbbreviateSpan__" + uniqueId + "').hide('slow'); return false;\">");
     result.append(TextContainer.textOrNull("guiAbbreviateShow"));
     result.append("</a></span>");
-    result.append("<textarea cols=\"" + this.cols + "\" rows=\"" + this.rows 
-        + "\" style=\"display: none\" id=\"grouperAbbreviateTextarea__" + uniqueId + "\">");
+    result.append("<textarea cols=\"" + this.cols + "\" rows=\"" + this.rows
+        + "\" style=\"display: none\" aria-label=\"" + GrouperUtil.xmlEscape(TextContainer.textOrNull("guiAbbreviateTextareaAriaLabel"))
+        + "\" id=\"grouperAbbreviateTextarea__" + uniqueId + "\">");
     result.append(GrouperUtil.xmlEscape(this.text));
     result.append("</textarea>");
     this.getJspContext().getOut().print(result.toString());

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobAdd.jsp
@@ -46,7 +46,7 @@
 					  </td>
 					</tr>
 					<tr>
-                      <td style="vertical-align: top; white-space: nowrap;"><strong><label for="daemonTypeId">${textContainer.text['grouperDaemonConfigEnableLabel']}</label></strong></td>
+                      <td style="vertical-align: top; white-space: nowrap;"><strong><label for="daemonConfigEnableId">${textContainer.text['grouperDaemonConfigEnableLabel']}</label></strong></td>
                       <td>&nbsp;</td>
                       <td>
 						<select name="daemonConfigEnable" id="daemonConfigEnableId" style="width: 30em">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobEdit.jsp
@@ -50,7 +50,7 @@
 						</c:if>
 						
 						<tr>
-	                      <td style="vertical-align: top; white-space: nowrap;"><strong><label for="daemonTypeId">${textContainer.text['grouperDaemonConfigEnableLabel']}</label></strong></td>
+	                      <td style="vertical-align: top; white-space: nowrap;"><strong><label for="daemonConfigEnableId">${textContainer.text['grouperDaemonConfigEnableLabel']}</label></strong></td>
 	                      <td>&nbsp;</td>
 	                      <td>
 							<select name="daemonConfigEnable" id="daemonConfigEnableId" style="width: 30em">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobs.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobs.jsp
@@ -66,7 +66,7 @@ ${grouper:title('adminDaemonJobsPageTitle')}
                   <div class="row-fluid" style="margin-top: 0.5em">
                     <div class="span1">&nbsp;</div>
                     <div class="span4" style="white-space: nowrap;">
-                      <select name="daemonJobsCommonFilter" id="daemonJobsCommonFilterId">
+                      <select name="daemonJobsCommonFilter" id="daemonJobsCommonFilterId" aria-label="${textContainer.textEscapeXml['daemonJobsCommonSearchNamePlaceholder']}">
                         <option value="" style="color:#aaaaaa !important">${textContainer.textEscapeXml['daemonJobsCommonSearchNamePlaceholder'] }</option>
                         <c:forEach items="${grouperRequestContainer.adminContainer.daemonJobsCommonFilters}" var="daemonJobsCommonFilter" >
                           <option value="${grouper:escapeHtml(daemonJobsCommonFilter.value)}"
@@ -81,7 +81,7 @@ ${grouper:title('adminDaemonJobsPageTitle')}
                   <div class="row-fluid" style="margin-top: 0.5em">
                     <div class="span1">&nbsp;</div>
                     <div class="span4" style="white-space: nowrap;">
-                      <select name="daemonJobsStatusFilter" id="daemonJobsStatusFilterId">
+                      <select name="daemonJobsStatusFilter" id="daemonJobsStatusFilterId" aria-label="${textContainer.textEscapeXml['daemonJobsStatusSearchNamePlaceholder']}">
                         <option value="" style="color:#aaaaaa !important">${textContainer.textEscapeXml['daemonJobsStatusSearchNamePlaceholder'] }</option>
                         <c:forEach items="${grouperRequestContainer.adminContainer.daemonJobsStatusFilters}" var="daemonJobsStatusFilter" >
                           <option value="${grouper:escapeHtml(daemonJobsStatusFilter.value)}"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefAssignAddMetadataAssignment.jsp
@@ -51,7 +51,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefContents.jsp
@@ -14,6 +14,7 @@
                         <th>
                           <label class="checkbox checkbox-no-padding">
                             <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.attributeDefNameCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                            <span class="sr-only">${textContainer.text['attributeDefDetailsCheckboxAriaLabel']}</span>
                           </label>
                         </th>
                       </c:if>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefEdit.jsp
@@ -35,7 +35,7 @@
                     </div>
                   </div>
                   <div class="control-group">
-                    <label for="attributeDefType" class="control-label">${textContainer.text['attributeDefCreateTypeLabel'] }</label>
+                    <label for="attributeDefTypeId" class="control-label">${textContainer.text['attributeDefCreateTypeLabel'] }</label>
                     <div class="controls">
                       <select name="attributeDefType" id="attributeDefTypeId" 
                           onchange="ajax('../app/UiV2AttributeDef.attributeDefTypeChanged', {formIds: 'editAttributeDefForm'}); return false;">
@@ -51,7 +51,7 @@
                     </div>
                   </div>
                   <div class="control-group">
-                    <label for="attributeDefValueType" class="control-label" id="assignToLabelId">${textContainer.text['attributeDefLabelAssignTo'] }</label>
+                    <span class="control-label" id="assignToLabelId">${textContainer.text['attributeDefLabelAssignTo'] }</span>
                     <div class="controls">
                        <table class="attributeDefAssignToTable">
                          <tr>
@@ -59,18 +59,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToAttributeDef" id="attributeDefToEditAssignToAttributeDefId"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToAttributeDefDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToAttributeDefId">
                              ${textContainer.text['attributeDefAssignTo.attributeDef']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToAttributeDefAssign" id="attributeDefToEditAssignToAttributeDefAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToAttributeDefAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToAttributeDefAssignId">
                              ${textContainer.text['attributeDefAssignTo.attributeDefAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -78,18 +78,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToStem" id="attributeDefToEditAssignToStemId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToStemDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox" for="attributeDefToEditAssignToStemId">
                              ${textContainer.text['attributeDefAssignTo.stem']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToStemAssign" id="attributeDefToEditAssignToStemAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToStemAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToStemAssignId">
                              ${textContainer.text['attributeDefAssignTo.stemAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -97,18 +97,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToGroup" id="attributeDefToEditAssignToGroupId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToGroupDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToGroupId">
                              ${textContainer.text['attributeDefAssignTo.group']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToGroupAssign" id="attributeDefToEditAssignToGroupAssignId" 
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToGroupAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToGroupAssignId">
                              ${textContainer.text['attributeDefAssignTo.groupAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -116,18 +116,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToMember" id="attributeDefToEditAssignToMemberId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToMemberDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMemberId">
                              ${textContainer.text['attributeDefAssignTo.member']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToMemberAssign" id="attributeDefToEditAssignToMemberAssignId"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToMemberAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToMemberAssignId">
                              ${textContainer.text['attributeDefAssignTo.memberAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -135,18 +135,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToMembership" id="attributeDefToEditAssignToMembershipId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToEffMembershipDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMembershipId">
                              ${textContainer.text['attributeDefAssignTo.membership']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToMembershipAssign" id="attributeDefToEditAssignToMembershipAssignId"
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToEffMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToMembershipAssignId">
                              ${textContainer.text['attributeDefAssignTo.membershipAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -154,18 +154,18 @@
                              <input type="checkbox" name="attributeDefToEditAssignToImmediateMembership" id="attributeDefToEditAssignToImmediateMembershipId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToImmMembershipDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToImmediateMembershipId">
                              ${textContainer.text['attributeDefAssignTo.immediateMembership']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToImmediateMembershipAssign" id="attributeDefToEditAssignToImmediateMembershipAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToImmMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToImmediateMembershipAssignId">
                              ${textContainer.text['attributeDefAssignTo.immediateMembershipAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                        </table>
@@ -178,7 +178,7 @@
                     <label for="attributeDefMultiAssignable" class="control-label">${textContainer.text['attributeDefMultiAssignable'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiAssignable" value="true" 
+                      <input type="checkbox" name="attributeDefMultiAssignable" id="attributeDefMultiAssignable" value="true" 
                          ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.multiAssignableDb == 'T' ? 'checked="checked"' : '' }
                       />
                       <span class="help-block">${textContainer.text['attributeDefMultiAssignableDescription'] }</span>
@@ -187,7 +187,7 @@
                   
                   
                   <div class="control-group">
-                    <label for="attributeDefValueType" class="control-label">${textContainer.text['attributeDefCreateValueTypeLabel'] }</label>
+                    <label for="attributeDefValueTypeId" class="control-label">${textContainer.text['attributeDefCreateValueTypeLabel'] }</label>
                     <div class="controls">
                       <select name="attributeDefValueType" id="attributeDefValueTypeId"
                           onchange="ajax('../app/UiV2AttributeDef.attributeDefValueTypeChanged', {formIds: 'editAttributeDefForm'}); return false;">
@@ -208,7 +208,7 @@
                     <label for="attributeDefMultiValued" class="control-label">${textContainer.text['attributeDefMultiValued'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiValued" 
+                      <input type="checkbox" name="attributeDefMultiValued" id="attributeDefMultiValued" 
                         ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.multiValuedDb == 'T' ? 'checked="checked"' : '' }
                       value="true" />
                       <span class="help-block">${textContainer.text['attributeDefMultiValuedDescription'] }</span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefHeader.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefHeader.jsp
@@ -13,10 +13,10 @@
                       </div>
                       <div class="modal-body">
                         <form class="form form-inline" id="addMemberSearchFormId">
-                          <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                          <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                           <button class="btn" onclick="ajax('../app/UiV2AttributeDef.addMemberSearch?attributeDefId=${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.id}', {formIds: 'addMemberSearchFormId'}); return false;" >${textContainer.text['attributeDefSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['attributeDefLabelExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['attributeDefLabelExactIdMatch']}"/> ${textContainer.text['attributeDefLabelExactIdMatch'] }</span>
                           <br />
                           <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                           <select name="sourceId">
@@ -44,7 +44,7 @@
                       <div id="add-members">
                         <form id="add-members-form" target="#" class="form-horizontal form-highlight">
                           <div class="control-group">
-                            <label for="add-block-input" class="control-label">${textContainer.text['attributeDefSearchMemberOrId'] }</label>
+                            <label for="groupAddMemberComboId" class="control-label">${textContainer.text['attributeDefSearchMemberOrId'] }</label>
                             <div class="controls">
                               <div id="add-members-container">
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefPrivilegeContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefPrivilegeContents.jsp
@@ -51,6 +51,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['attributeDefPrivilegesCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th class="sorted" style="width: 35em">Entity name</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/newAttributeDef.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/newAttributeDef.jsp
@@ -31,7 +31,7 @@ ${grouper:title('newAttributeDefPageTitle')}
                 </div>
                 <form id="addAttributeDefForm" class="form-horizontal">
                   <div class="control-group">
-                    <label for="folder-path" class="control-label">${textContainer.text['attributeDefCreateFolderLabel'] }</label>
+                    <label for="parentFolderComboId" class="control-label">${textContainer.text['attributeDefCreateFolderLabel'] }</label>
                     <div class="controls">
                       <%-- placeholder: Enter a folder name --%>
                       <grouper:combobox2 idBase="parentFolderCombo" style="width: 30em" 
@@ -56,7 +56,7 @@ ${grouper:title('newAttributeDefPageTitle')}
                     </div>
                   </div>
                   <div class="control-group">
-                    <label for="attributeDefType" class="control-label">${textContainer.text['attributeDefCreateTypeLabel'] }</label>
+                    <label for="attributeDefTypeId" class="control-label">${textContainer.text['attributeDefCreateTypeLabel'] }</label>
                     <div class="controls">
                       <select name="attributeDefType" id="attributeDefTypeId" 
                           onchange="ajax('../app/UiV2AttributeDef.attributeDefTypeChanged', {formIds: 'addAttributeDefForm'}); return false;">
@@ -72,7 +72,7 @@ ${grouper:title('newAttributeDefPageTitle')}
                     </div>
                   </div>
                   <div class="control-group">
-                    <label for="attributeDefValueType" class="control-label" id="assignToLabelId">${textContainer.text['attributeDefLabelAssignTo'] }</label>
+                    <span class="control-label" id="assignToLabelId">${textContainer.text['attributeDefLabelAssignTo'] }</span>
                     <div class="controls">
                        <table class="attributeDefAssignToTable">
                          <tr>
@@ -80,18 +80,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToAttributeDef" id="attributeDefToEditAssignToAttributeDefId"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToAttributeDefDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToAttributeDefId">
                              ${textContainer.text['attributeDefAssignTo.attributeDef']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToAttributeDefAssign" id="attributeDefToEditAssignToAttributeDefAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToAttributeDefAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToAttributeDefAssignId">
                              ${textContainer.text['attributeDefAssignTo.attributeDefAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -99,18 +99,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToStem" id="attributeDefToEditAssignToStemId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToStemDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox" for="attributeDefToEditAssignToStemId">
                              ${textContainer.text['attributeDefAssignTo.stem']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToStemAssign" id="attributeDefToEditAssignToStemAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToStemAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToStemAssignId">
                              ${textContainer.text['attributeDefAssignTo.stemAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -118,18 +118,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToGroup" id="attributeDefToEditAssignToGroupId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToGroupDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToGroupId">
                              ${textContainer.text['attributeDefAssignTo.group']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToGroupAssign" id="attributeDefToEditAssignToGroupAssignId" 
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToGroupAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToGroupAssignId">
                              ${textContainer.text['attributeDefAssignTo.groupAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -137,18 +137,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToMember" id="attributeDefToEditAssignToMemberId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToMemberDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMemberId">
                              ${textContainer.text['attributeDefAssignTo.member']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToMemberAssign" id="attributeDefToEditAssignToMemberAssignId"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToMemberAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToMemberAssignId">
                              ${textContainer.text['attributeDefAssignTo.memberAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -156,18 +156,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToMembership" id="attributeDefToEditAssignToMembershipId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToEffMembershipDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMembershipId">
                              ${textContainer.text['attributeDefAssignTo.membership']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToMembershipAssign" id="attributeDefToEditAssignToMembershipAssignId"
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToEffMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToMembershipAssignId">
                              ${textContainer.text['attributeDefAssignTo.membershipAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                          <tr>
@@ -175,18 +175,18 @@ ${grouper:title('newAttributeDefPageTitle')}
                              <input type="checkbox" name="attributeDefToEditAssignToImmediateMembership" id="attributeDefToEditAssignToImmediateMembershipId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToImmMembershipDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToImmediateMembershipId">
                              ${textContainer.text['attributeDefAssignTo.immediateMembership']}
-                             </span>
+                             </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
                              <input type="checkbox" name="attributeDefToEditAssignToImmediateMembershipAssign" id="attributeDefToEditAssignToImmediateMembershipAssignId" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${attributeUpdateRequestContainer.attributeDefToEdit.assignToImmMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
-                             <span class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox">
+                             <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox" for="attributeDefToEditAssignToImmediateMembershipAssignId">
                              ${textContainer.text['attributeDefAssignTo.immediateMembershipAssign']}
-                             </span>
+                             </label>
                            </td>
                          </tr>
                        </table>
@@ -199,14 +199,14 @@ ${grouper:title('newAttributeDefPageTitle')}
                     <label for="attributeDefMultiAssignable" class="control-label">${textContainer.text['attributeDefMultiAssignable'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiAssignable" value="true" />
+                      <input type="checkbox" name="attributeDefMultiAssignable" id="attributeDefMultiAssignable" value="true" />
                       <span class="help-block">${textContainer.text['attributeDefMultiAssignableDescription'] }</span>
                     </div>
                   </div>
                   
                   
                   <div class="control-group attribute-def-value-all-values">
-                    <label for="attributeDefValueType" class="control-label">${textContainer.text['attributeDefCreateValueTypeLabel'] }</label>
+                    <label for="attributeDefValueTypeId" class="control-label">${textContainer.text['attributeDefCreateValueTypeLabel'] }</label>
                     <div class="controls">
                       <select name="attributeDefValueType" id="attributeDefValueTypeId"
                           onchange="ajax('../app/UiV2AttributeDef.attributeDefValueTypeChanged', {formIds: 'addAttributeDefForm'}); return false;">
@@ -227,7 +227,7 @@ ${grouper:title('newAttributeDefPageTitle')}
                     <label for="attributeDefMultiValued" class="control-label">${textContainer.text['attributeDefMultiValued'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiValued" value="true" />
+                      <input type="checkbox" name="attributeDefMultiValued" id="attributeDefMultiValued" value="true" />
                       <span class="help-block">${textContainer.text['attributeDefMultiValuedDescription'] }</span>
                     </div>
                   </div>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/viewAttributeDef.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/viewAttributeDef.jsp
@@ -18,7 +18,7 @@ ${grouper:titleFromKeyAndText('viewAttributeDefPageTitle', grouperRequestContain
                 <form class="form-inline form-small form-filter" id="attributeDefFilterFormId">
                   <div class="row-fluid">
                     <div class="span1">
-                      <label for="people-filter">${textContainer.text['attributeDefFilterFor'] }</label>
+                      <label for="table-filter">${textContainer.text['attributeDefFilterFor'] }</label>
                     </div>
                     <div class="span4">
                       <input type="text" placeholder="${textContainer.textEscapeXml['attributeDefFilterFormPlaceholder']}" 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActions.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActions.jsp
@@ -14,6 +14,7 @@
                         <th>
                           <label class="checkbox checkbox-no-padding">
                             <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.attributeDefActionCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                            <span class="sr-only">${textContainer.text['attributeDefDetailsCheckboxAriaLabel']}</span>
                           </label>
                         </th>
                       </c:if>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActionsPage.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActionsPage.jsp
@@ -20,7 +20,7 @@
                     </div>
                     <div class="span4">
                       <input type="text" placeholder="${textContainer.textEscapeXml['attributeDefActionFilterFormPlaceholder']}" 
-                         name="filterText" id="table-filter" class="span12"/>
+                         name="filterText" id="table-filter" aria-label="${textContainer.textEscapeXml['attributeDefActionFilterFormPlaceholder']}" class="span12"/>
                     </div>
 
                     <div class="span3"><input type="submit" class="btn" aria-controls="attributeDefFilterResultsId" id="filterSubmitId" value="${textContainer.textEscapeDouble['attributeDefApplyFilterButton'] }"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/newAttributeDefAction.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/newAttributeDefAction.jsp
@@ -14,7 +14,7 @@
                 <form id="addAttributeActionForm" class="form-horizontal">
                 
                   <div class="control-group">
-                    <label class="control-label">${textContainer.text['attributeDefActionCreateAttributeDefLabel'] }</label>
+                    <label for="attributeDefComboId" class="control-label">${textContainer.text['attributeDefActionCreateAttributeDefLabel'] }</label>
                     <div class="controls">
                     	                    	
                       <grouper:combobox2 idBase="attributeDefCombo" style="width: 30em" 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAttribute/attributeDefAttributeAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAttribute/attributeDefAttributeAssignAddMetadataAssignment.jsp
@@ -52,7 +52,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAttribute/attributeDefAttributeAssignmentSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAttribute/attributeDefAttributeAssignmentSection.jsp
@@ -17,7 +17,7 @@
           <form id="assignAttributeForm" class="form-horizontal">
              <input type="hidden" name="attributeDefId" value="${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.id}" />
              <div class="control-group">
-               <label class="control-label">${textContainer.text['attributeDefAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['attributeDefAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"
                    filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameAssignAddMetadataAssignment.jsp
@@ -51,7 +51,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/newAttributeDefName.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/newAttributeDefName.jsp
@@ -19,7 +19,7 @@ ${grouper:title('newAttributeDefNamePageTitle')}
                   </div>
                   <div class="modal-body">
                     <form class="form form-inline" id="stemSearchFormId">
-                      <input name="stemSearch" type="text" placeholder="${textContainer.textEscapeXml['attributeDefNameCreateSearchPlaceholder'] }" value=""/> 
+                      <input name="stemSearch" type="text" aria-label="${textContainer.textEscapeXml['attributeDefNameCreateSearchPlaceholder']}" placeholder="${textContainer.textEscapeXml['attributeDefNameCreateSearchPlaceholder'] }" value=""/> 
                       <button class="btn" onclick="ajax('../app/UiV2Stem.stemSearchAttributeDefNameFormSubmit?stemId=${grouperRequestContainer.stemContainer.guiStem.stem.id}', {formIds: 'stemSearchFormId'}); return false;">${textContainer.text['attributeDefNameCreateSearchButton'] }</button>
                     </form>
                     <div id="folderSearchResultsId"></div>
@@ -33,7 +33,7 @@ ${grouper:title('newAttributeDefNamePageTitle')}
                 <form id="addAttributeNameForm" class="form-horizontal">
                 
                   <div class="control-group">
-                    <label class="control-label">${textContainer.text['attributeDefNameCreateAttributeDefLabel'] }</label>
+                    <label for="attributeDefComboId" class="control-label">${textContainer.text['attributeDefNameCreateAttributeDefLabel'] }</label>
                     <div class="controls">
                     	                    	
                       <grouper:combobox2 idBase="attributeDefCombo" style="width: 30em" 
@@ -46,7 +46,7 @@ ${grouper:title('newAttributeDefNamePageTitle')}
                   </div>
                   
                   <div class="control-group">
-                    <label for="folder-path" class="control-label">${textContainer.text['attributeDefNameCreateFolderLabel'] }</label>
+                    <label for="parentFolderComboId" class="control-label">${textContainer.text['attributeDefNameCreateFolderLabel'] }</label>
                     <div class="controls">
                       <%-- placeholder: Enter a folder name --%>
                       <grouper:combobox2 idBase="parentFolderCombo" style="width: 30em" 
@@ -76,7 +76,7 @@ ${grouper:title('newAttributeDefNamePageTitle')}
                         <input type="text" id="attributeDefNameId" name="attributeDefNameToEditExtension" disabled="disabled"  />
                       </span>
                       <span style="white-space: nowrap;">
-                        <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true"
+                        <input type="checkbox" name="nameDifferentThanId" aria-label="${textContainer.textEscapeXml['groupNewEditTheId']}" id="nameDifferentThanIdId" value="true"
                           onchange="syncNameAndId('name', 'attributeDefNameId', 'nameDifferentThanIdId', false, null); return true;"
                         /> ${textContainer.text['groupNewEditTheId'] }
                       </span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwtConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwtConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.authenticationContainer.guiWsTrustedJwtConfiguration}" var="guiWsTrustedJwtConfiguration"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="wsTrustedJwtConfigId">${textContainer.text['wsTrustedJwtConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="configId">${textContainer.text['wsTrustedJwtConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileAddEntry.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileAddEntry.jsp
@@ -36,7 +36,7 @@
               <div id="configuration-select-container">
                <form id="configurationSelectForm" class="form-horizontal" method="post" action="UiV2Configure.configure" >
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationSelectConfigFile'] }</label>
+                   <label class="control-label" for="configFileSelect">${textContainer.text['configurationSelectConfigFile'] }</label>
                    <div class="controls">
                      <%-- --%>
                      <select id="configFileSelect" class="span10" name="configFile" 
@@ -61,7 +61,7 @@
                  </div>
                  
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryPropertyName'] }</label>
+                   <label for="propertyNameId" class="control-label">${textContainer.text['configurationFilesAddEntryPropertyName'] }</label>
                    <div class="controls">
                      <input type="text" id="propertyNameId" class="span10" name="propertyNameName" />
                      
@@ -71,7 +71,7 @@
                  </div>
 
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryExpressionLanguage'] }</label>
+                   <label for="expressionLanguageId" class="control-label">${textContainer.text['configurationFilesAddEntryExpressionLanguage'] }</label>
                    <div class="controls">
                      <select id="expressionLanguageId" class="span10" name="expressionLanguageName">
                        <option value="false">${textContainer.text['configurationFilesAddEntryExpressionLanguageFalse'] }</option>
@@ -84,7 +84,7 @@
                    </div>
                  </div>
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryPasswordLabel'] }</label>
+                   <label for="passwordId" class="control-label">${textContainer.text['configurationFilesAddEntryPasswordLabel'] }</label>
                    <div class="controls">
                      <select id="passwordId" class="span10" name="passwordName" onchange="return ajax('../app/UiV2Configure.configurationFileSelectPassword', {formIds: 'configurationSelectForm'}); return false;">
                        <option value="false">${textContainer.text['configurationFilesAddEntryPasswordFalse'] }</option>
@@ -98,7 +98,7 @@
                  </div>
 
                  <div class="control-group" id="passwordValueDivId" style="display: none">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryPasswordFieldLabel'] }</label>
+                   <label for="passwordValueId" class="control-label">${textContainer.text['configurationFilesAddEntryPasswordFieldLabel'] }</label>
                    <div class="controls">
                      <input type="password" id="passwordValueId" class="span10" name="passwordValueName" />
                      
@@ -108,7 +108,7 @@
                  </div>
 
                  <div class="control-group" id="valueDivId">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryValue'] }</label>
+                   <label for="valueId" class="control-label">${textContainer.text['configurationFilesAddEntryValue'] }</label>
                    <div class="controls">
                      <textarea rows="8" cols="50" id="valueId" class="span10" name="valueName"></textarea>
                      

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileEditEntry.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileEditEntry.jsp
@@ -9,7 +9,7 @@
                  <input type="hidden" name="propertyNameName" value="${grouperRequestContainer.configurationContainer.currentConfigPropertyName}" />
 
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryExpressionLanguage'] }</label>
+                   <label for="expressionLanguageId" class="control-label">${textContainer.text['configurationFilesAddEntryExpressionLanguage'] }</label>
                    <div class="controls">
                      <select id="expressionLanguageId" class="span6" name="expressionLanguageName">
                        <option value="false" ${!grouperRequestContainer.configurationContainer.currentGuiConfigProperty.scriptlet ? 'selected="selected"' : '' } 
@@ -24,7 +24,7 @@
                    </div>
                  </div>
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationFilesAddEntryPasswordLabel'] }</label>
+                   <label for="passwordId" class="control-label">${textContainer.text['configurationFilesAddEntryPasswordLabel'] }</label>
                    <div class="controls">
                      <select id="passwordId" class="span6" name="passwordName" onchange="return ajax('../app/UiV2Configure.configurationFileSelectPassword', {formIds: 'configurationEditForm'}); return false;">
                        <option value="false" ${!grouperRequestContainer.configurationContainer.currentGuiConfigProperty.encryptedInDatabase ? 'selected="selected"' : '' }
@@ -40,7 +40,7 @@
                  </div>
                 <div class="control-group" id="passwordValueDivId" 
                    style="display: ${grouperRequestContainer.configurationContainer.currentGuiConfigProperty.encryptedInDatabase ? 'block' : 'none'}">
-                 <label class="control-label">${textContainer.text['configurationFilesAddEntryPasswordFieldLabel'] }</label>
+                 <label for="passwordValueId" class="control-label">${textContainer.text['configurationFilesAddEntryPasswordFieldLabel'] }</label>
                  <div class="controls">
                    <input type="password" id="passwordValueId" class="span6" name="passwordValueName" />
                    
@@ -50,7 +50,7 @@
                </div>
                <div class="control-group" id="valueDivId" 
                    style="display: ${!grouperRequestContainer.configurationContainer.currentGuiConfigProperty.encryptedInDatabase ? 'block' : 'none'}">
-                 <label class="control-label">${textContainer.text['configurationFilesAddEntryValue'] }</label>
+                 <label for="valueId" class="control-label">${textContainer.text['configurationFilesAddEntryValue'] }</label>
                  <div class="controls">
                  
                    <textarea rows="8" cols="50" id="valueId" class="span6" name="valueName">${grouper:escapeHtml(grouperRequestContainer.configurationContainer.currentGuiConfigProperty.configItemMetadata.sampleProperty ? '' : 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileImport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileImport.jsp
@@ -52,7 +52,7 @@
               <div class="config-import-file">
                    
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationSelectConfigFile'] }</label>
+                   <label class="control-label" for="importConfigFileId">${textContainer.text['configurationSelectConfigFile'] }</label>
                    <div class="controls">
                      
                      <input type="file" name="importConfigFile" id="importConfigFileId" />
@@ -65,7 +65,7 @@
               <div class="config-import-copyPaste hide">
 
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationImportSelectConfigFile'] }</label>
+                   <label class="control-label" for="configFileSelect">${textContainer.text['configurationImportSelectConfigFile'] }</label>
                    <div class="controls">
                      <select id="configFileSelect" class="span4" name="configFile" >
                         <option value=""></option>
@@ -88,7 +88,7 @@
                  </div>
                    
                  <div class="control-group">
-                   <label class="control-label">${textContainer.text['configurationImportConfigFileCopyPaste'] }</label>
+                   <label class="control-label" for="configInputCopyPasteId">${textContainer.text['configurationImportConfigFileCopyPaste'] }</label>
                    <div class="controls">
                      <textarea id="configInputCopyPasteId" name="configInputCopyPasteName" rows="10" cols="40" 
                      class="input-block-level"></textarea><span class="help-block">${textContainer.text['configurationImportConfigFileCopyPasteDescription'] }</span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configure.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configure.jsp
@@ -24,7 +24,7 @@
                 <div id="configuration-select-container">
                  <form id="configurationSelectForm" class="form-horizontal" method="post" action="UiV2Configure.configure" >
                    <div class="control-group">
-                     <label class="control-label">${textContainer.text['configurationSelectConfigFile'] }</label>
+                     <label class="control-label" for="configFileSelect">${textContainer.text['configurationSelectConfigFile'] }</label>
                      <div class="controls">
                        <%-- --%>
                        <select id="configFileSelect" class="span4" name="configFile" 
@@ -87,7 +87,7 @@
 						<div class="span1"></div>              			              		             		
 						<div class="span4">
 	                      <input type="text" placeholder="${textContainer.textEscapeXml['configurationFilterTextPlaceholder']}" 
-	                         name="filter" id="table-filter" class="span12" value="${grouperRequestContainer.configurationContainer.filter}" />
+	                         name="filter" id="table-filter" aria-label="${textContainer.textEscapeXml['configurationFilterTextPlaceholder']}" class="span12" value="${grouperRequestContainer.configurationContainer.filter}" />
 	                    </div>
 						<div class="span4">
 							<input type="submit" class="btn" aria-controls="propertiesResultTableId"  id="filterSubmitId" value="${textContainer.textEscapeDouble['configurationFilterApplyButton'] }"
@@ -131,7 +131,7 @@
                                   <td colspan="2" class="table-toolbar gradient-background">
                                   
                                    
-                                    <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" style="margin-top: 0px;" onchange="$('.configCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                                    <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" aria-label="${textContainer.text['configurationSelectConfigCheckboxAriaLabel']}" style="margin-top: 0px;" onchange="$('.configCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
                                     <span>
                                       ${textContainer.text['configurationDeleteSelectConfigs'] }
                                     </span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/history.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/history.jsp
@@ -30,7 +30,7 @@
               	<form id="configureHistoryFilterForm" style="height: 20px;">
 					<div class="span4">
                       <input type="text" placeholder="${textContainer.textEscapeXml['configurationFilterTextPlaceholder']}" 
-                         name="filter" id="table-filter" class="span12" value="${grouperRequestContainer.configurationContainer.filter}" />
+                         name="filter" id="table-filter" aria-label="${textContainer.textEscapeXml['configurationFilterTextPlaceholder']}" class="span12" value="${grouperRequestContainer.configurationContainer.filter}" />
                     </div>
 					<div class="span3">
 						<input type="submit" class="btn" aria-controls="propertiesResultTableId"  id="filterSubmitId" value="${textContainer.textEscapeDouble['configurationFilterApplyButton'] }"
@@ -53,6 +53,7 @@
 	                         <label class="checkbox checkbox-no-padding">
 	                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" 
 	                           	onchange="$('.configHistoryCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+	                           <span class="sr-only">${textContainer.text['configurationHistoryRevertValueCheckboxAriaLabel']}</span>
 	                         </label>
 	                        </th>
 	                        

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningAttributeDefReport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningAttributeDefReport.jsp
@@ -46,6 +46,7 @@
                   <label class="checkbox checkbox-no-padding">
                     <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" checked="checked"
                       onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                    <span class="sr-only">${textContainer.text['groupMembershipsInOtherGropusCheckboxAriaLabel']}</span>
                   </label>
                 </th>
                 <th>${textContainer.text['deprovisioningSubjectColumn'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningFolderReport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningFolderReport.jsp
@@ -43,6 +43,7 @@ ${grouper:titleFromKeyAndText('stemDeprovisioningReportPageTitle', grouperReques
                   <label class="checkbox checkbox-no-padding">
                     <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" checked="checked"
                       onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                    <span class="sr-only">${textContainer.text['groupMembershipsInOtherGropusCheckboxAriaLabel']}</span>
                   </label>
                 </th>
                 <th>${textContainer.text['deprovisioningSubjectColumn'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningGroupReport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningGroupReport.jsp
@@ -48,6 +48,7 @@ ${grouper:titleFromKeyAndText('groupDeprovisioningReportPageTitle', grouperReque
                   <label class="checkbox checkbox-no-padding">
                     <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" checked="checked"
                       onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                    <span class="sr-only">${textContainer.text['groupMembershipsInOtherGropusCheckboxAriaLabel']}</span>
                   </label>
                 </th>
                 <th>${textContainer.text['deprovisioningSubjectColumn'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningSelectAffiliation.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningSelectAffiliation.jsp
@@ -3,7 +3,7 @@
 <div id="affiliation-select-container">
                 <form id="affiliationSelectForm" class="form-horizontal" method="get" action="UiV2Deprovisioning.${deprovisioningSelectAffiliationTarget}" >
                    <div class="control-group">
-                     <label class="control-label">${textContainer.text['deprovisioningSelectAffiliationLabel'] }</label>
+                     <label for="affiliationFilter" class="control-label">${textContainer.text['deprovisioningSelectAffiliationLabel'] }</label>
                      <div class="controls">
                        <%-- --%>
                        <select id="affiliationFilter" class="span2" name="affiliation" 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUserResults.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUserResults.jsp
@@ -28,6 +28,7 @@ ${textContainer.text['deprovisioningUserResultsDescription'] }
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" checked="checked"
                             onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupMembershipsInOtherGropusCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th data-hide="phone,medium">${textContainer.text['thisGroupsMembershipsFolderColumn'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUserSearch.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUserSearch.jsp
@@ -8,10 +8,10 @@
                 </div>
                 <div class="modal-body">
                   <form class="form form-inline" id="deprovisionSearchFormId">
-                    <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                    <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                     <button class="btn" onclick="ajax('../app/UiV2Deprovisioning.addMemberSearch', {formIds: 'deprovisionSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                     <br />
-                    <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+                    <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
                     <br />
                     <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                     <select name="sourceId">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalEntities/invite.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalEntities/invite.jsp
@@ -26,7 +26,7 @@
                       <input name="groupFilter" type="text" id="groupFilterId" placeholder="${textContainer.text['inviteExternalSearchGroupPlaceholder']}" value=""/> 
                       <button class="btn" onclick="ajax('../app/UiV2ExternalEntities.inviteSearchGroupFormSubmit', {formIds: 'groupSearchFormId'}); return false;">${textContainer.text['inviteExternalSearchGroupButton']}</button>
                       <br />
-                      <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['inviteExternalSearchExactIdMatch'] }</span>
+                      <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['inviteExternalSearchExactIdMatch']}"/> ${textContainer.text['inviteExternalSearchExactIdMatch'] }</span>
                     </form>
                     <div id="groupSearchResultsId"></div>
                   </div>
@@ -88,7 +88,7 @@
                   <c:if test="${grouperRequestContainer.inviteExternalContainer.allowInviteByIdentifier}">
                     <div class="invite-external-id-container hide">
                       <div class="control-group">
-                        <label for="external-invite-ids" class="control-label">${textContainer.text['inviteExternalLabelUserIds']}</label>
+                        <label for="loginIdsToInvite" class="control-label">${textContainer.text['inviteExternalLabelUserIds']}</label>
                         <div class="controls">
                           <textarea id="loginIdsToInvite" rows="3" cols="40" class="input-block-level"></textarea><span class="help-block">${textContainer.text['inviteExternalUserIdsHelp']}</span>
                         </div>
@@ -97,7 +97,7 @@
                   </c:if>                  
                   <div class="bulk-add-group-input-container">
                     <div class="control-group bulk-add-group-block">
-                      <label for="add-entities" style="position:absolute" class="control-label">${textContainer.text['inviteExternalLabelGroupToAddToNewUsers'] }</label>
+                      <label for="inviteAddGroupComboId" style="position:absolute" class="control-label">${textContainer.text['inviteExternalLabelGroupToAddToNewUsers'] }</label>
                       <div class="controls">
                         <grouper:combobox2 idBase="inviteAddGroupCombo" style="width: 30em"
                            value="${grouperRequestContainer.groupContainer.guiGroup.group.id}"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/externalSystemConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/externalSystemConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set  value="${grouperRequestContainer.externalSystemContainer.guiGrouperExternalSystem}" var="guiGrouperExternalSystem"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="externalSystemConfigId">${textContainer.text['grouperExternalSystemConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="configId">${textContainer.text['grouperExternalSystemConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       <input type="text" style="width: 30em" value="${grouper:escapeHtml(guiGrouperExternalSystem.grouperExternalSystem.configId)}"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupAttestationViewAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupAttestationViewAudits.jsp
@@ -16,9 +16,9 @@
                     <option value="between">${textContainer.text['groupAuditLogFilterType_between']}</option>
                     <option value="since">${textContainer.text['groupAuditLogFilterType_since']}</option>
                   </select>
-                  <input id="from-date" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="from-date" aria-label="${textContainer.text['ariaLabelGuiFromDate']}" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;( ${textContainer.text['groupAuditLogFilterAndLabel'] }&nbsp;
-                  <input id="to-date" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="to-date" aria-label="${textContainer.text['ariaLabelGuiToDate']}" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;)
                   <label class="checkbox">
                     <input type="checkbox" name="showExtendedResults" value="true">${textContainer.text['groupAuditLogFilterShowExtendedResults']}

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupContents.jsp
@@ -21,6 +21,7 @@
                           <c:if test="${grouperRequestContainer.groupContainer.canUpdate && !grouperRequestContainer.groupContainer.showPointInTimeAudit}">
                             <label class="checkbox checkbox-no-padding">
                               <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                              <span class="sr-only">${textContainer.text['groupViewDetailsMembershipCheckboxAriaLabel']}</span>
                             </label>
                           </c:if>
                         </th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEdit.jsp
@@ -94,9 +94,9 @@ ${grouper:titleFromKeyAndText('groupEditPageTitle', grouperRequestContainer.grou
                              value="${userLifecyclePolicy.configId}"
                              <c:if test="${grouperRequestContainer.groupContainer.selectedUserLifeycyclePolicyConfigId == userLifecyclePolicy.configId}">checked</c:if> 
                       />
-                      <span for="ulp_${st.index}">
+                      <label for="ulp_${st.index}">
                         ${grouper:escapeHtml(userLifecyclePolicy.policyName)}
-                      </span>
+                      </label>
                       <span class="help-block">${userLifecyclePolicy.description}</span>
                       </br>
                     
@@ -110,7 +110,7 @@ ${grouper:titleFromKeyAndText('groupEditPageTitle', grouperRequestContainer.grou
                              value=""
                              <c:if test="${empty grouperRequestContainer.groupContainer.selectedUserLifeycyclePolicyConfigId}">checked</c:if> 
                       />
-                      <span for="ulp_none"> None</span>
+                      <label for="ulp_none"> None</label>
                     </div>
                   </div>
                   

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEditComposite.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEditComposite.jsp
@@ -21,10 +21,10 @@ ${grouper:titleFromKeyAndText('groupEditCompositePageTitle', grouperRequestConta
 
               <div class="modal-body">
                 <form class="form form-inline" id="leftFactorSearchFormId">
-                  <input id="leftFactorSearchId" name="leftFactorSearchName" type="text" placeholder="${textContainer.text['groupCompositeLeftFactorPlaceholder']}" />
+                  <input id="leftFactorSearchId" name="leftFactorSearchName" type="text" aria-label="${textContainer.textEscapeXml['groupCompositeLeftFactorPlaceholder']}" placeholder="${textContainer.text['groupCompositeLeftFactorPlaceholder']}" />
                   <button class="btn" onclick="ajax('../app/UiV2Group.leftGroupFactorSearch', {formIds: 'leftFactorSearchFormId'}); return false;" >${textContainer.text['groupCompositeSearchButton'] }</button>
                   <br />
-                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupCompositeSearchExactIdMatch'] }</span>
+                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupCompositeSearchExactIdMatch']}"/> ${textContainer.text['groupCompositeSearchExactIdMatch'] }</span>
                 </form>
                 <div id="leftFactorGroupResults">
                 </div>
@@ -41,10 +41,10 @@ ${grouper:titleFromKeyAndText('groupEditCompositePageTitle', grouperRequestConta
 
               <div class="modal-body">
                 <form class="form form-inline" id="rightFactorSearchFormId">
-                  <input id="rightFactorSearchId" name="rightFactorSearchName" type="text" placeholder="${textContainer.text['groupCompositeRightFactorPlaceholder']}" />
+                  <input id="rightFactorSearchId" name="rightFactorSearchName" type="text" aria-label="${textContainer.textEscapeXml['groupCompositeRightFactorPlaceholder']}" placeholder="${textContainer.text['groupCompositeRightFactorPlaceholder']}" />
                   <button class="btn" onclick="ajax('../app/UiV2Group.rightGroupFactorSearch', {formIds: 'rightFactorSearchFormId'}); return false;" >${textContainer.text['groupCompositeSearchButton'] }</button>
                   <br />
-                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupCompositeSearchExactIdMatch'] }</span>
+                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupCompositeSearchExactIdMatch']}"/> ${textContainer.text['groupCompositeSearchExactIdMatch'] }</span>
                 </form>
                 <div id="rightFactorGroupResults">
                 </div>
@@ -94,7 +94,7 @@ ${grouper:titleFromKeyAndText('groupEditCompositePageTitle', grouperRequestConta
                   </div>
                   <div class="control-group compositeDivClass" id="groupEditCompositeOfId" 
                       ${hasComposite ? '' : 'style="display:none"' }  >
-                    <label for="groupCompositeLeftFactorComboId" class="control-label">${textContainer.text['groupCompositeOperationLabel'] }</label>
+                    <label for="compositeOperationId" class="control-label">${textContainer.text['groupCompositeOperationLabel'] }</label>
                     <div class="controls">
                       <c:set var="compositeType" 
                         value="${hasComposite ? grouperRequestContainer.groupContainer.guiGroup.composite.type.name : null}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupHeader.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupHeader.jsp
@@ -17,10 +17,10 @@
                       </div>
                       <div class="modal-body">
                         <form class="form form-inline" id="addMemberSearchFormId">
-                          <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                          <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                           <button class="btn" onclick="ajax('../app/UiV2Group.addMemberSearch?groupId=${grouperRequestContainer.groupContainer.guiGroup.group.id}', {formIds: 'addMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
                           <br />
                           <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                           <select name="sourceId">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupPrivilegeContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupPrivilegeContents.jsp
@@ -52,6 +52,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupViewDetailsPrivilegesCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th class="sorted" style="width: 35em">Entity name</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupViewAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupViewAudits.jsp
@@ -27,9 +27,9 @@ ${grouper:titleFromKeyAndText('groupAuditsPageTitle', grouperRequestContainer.gr
                     <option value="between">${textContainer.text['groupAuditLogFilterType_between']}</option>
                     <option value="since">${textContainer.text['groupAuditLogFilterType_since']}</option>
                   </select>
-                  <input id="from-date" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="from-date" aria-label="${textContainer.text['ariaLabelGuiFromDate']}" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;( ${textContainer.text['groupAuditLogFilterAndLabel'] }&nbsp;
-                  <input id="to-date" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="to-date" aria-label="${textContainer.text['ariaLabelGuiToDate']}" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;)
                   <label class="checkbox">
                     <input type="checkbox" name="showExtendedResults" value="true">${textContainer.text['groupAuditLogFilterShowExtendedResults']}

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupViewHistoryChart.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupViewHistoryChart.jsp
@@ -47,7 +47,7 @@ ${grouper:titleFromKeyAndText('groupHistoryChartPageTitle', grouperRequestContai
 
                             <input type="text" name="dateFromRelative" id="dateFromRelativeId" class="span3" placeholder="${textContainer.text['groupHistoryChartRelativeScalePlaceholder'] }">
 
-                            <select name="dateFromRelativeScale" id="dateFromRelativeScale" class="span4">
+                            <select name="dateFromRelativeScale" id="dateFromRelativeScale" aria-label="${textContainer.textEscapeXml['groupHistoryChartRelativeScalePlaceholder']}" class="span4">
                               <option value="years" selected>${textContainer.text['groupHistoryChartRelativeScaleYears'] }</option>
                               <option value="months">${textContainer.text['groupHistoryChartRelativeScaleMonths'] }</option>
                               <option value="days" selected>${textContainer.text['groupHistoryChartRelativeScaleDays'] }</option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderEditGroupTab.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderEditGroupTab.jsp
@@ -38,10 +38,10 @@ ${grouper:titleFromKeyAndText('groupLoaderPageTitle', grouperRequestContainer.gr
                       </div>
                       <div class="modal-body">
                         <form class="form form-inline" id="addAnalyzeMemberSearchFormId">
-                          <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                          <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                           <button class="btn" onclick="ajax('../app/UiV2GrouperLoader.addMemberSearch?groupId=${grouperRequestContainer.groupContainer.guiGroup.group.id}', {formIds: 'addAnalyzeMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
                           <br />
                           <span style="white-space: nowrap;">${textContainer.text['find.search-source'] }
                           <select name="sourceId">
@@ -210,7 +210,7 @@ ${grouper:titleFromKeyAndText('groupLoaderPageTitle', grouperRequestContainer.gr
                         <c:if test="${grouperRequestContainer.grouperLoaderContainer.editLoaderType == 'RECENT_MEMBERSHIPS'}">
                           <c:if test="${grouperRequestContainer.grouperLoaderContainer.editLoaderShowRecentMemberships}">
                             <tr>
-                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperLoaderSqlTypeId">${textContainer.text['grouperLoaderRecentFromGroup']}</label></strong></td>
+                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="recentMembershipsFromGroupComboId">${textContainer.text['grouperLoaderRecentFromGroup']}</label></strong></td>
                               <td>
                                 <span style="white-space: nowrap">
                                   <table border="0" style="border:none;padding:0em; margin: 0em">
@@ -1120,7 +1120,7 @@ ${grouper:titleFromKeyAndText('groupLoaderPageTitle', grouperRequestContainer.gr
                           </tr>
                           <c:if test="${grouperRequestContainer.grouperLoaderContainer.customizeFailsafeTrue}">
                             <tr>
-                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="editLoaderFailsafeUseId">${textContainer.text['grouperLoaderFailsafeUseLabel']}</label></strong></td>
+                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="editFailsafeUseId">${textContainer.text['grouperLoaderFailsafeUseLabel']}</label></strong></td>
                               <td>
                                 <span style="white-space: nowrap">
                                   <select name="editFailsafeUseName" id="editFailsafeUseId" style="width: 30em">
@@ -1139,7 +1139,7 @@ ${grouper:titleFromKeyAndText('groupLoaderPageTitle', grouperRequestContainer.gr
                               </td>
                             </tr>
                             <tr>
-                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="editLoaderFailsafeSendEmailId">${textContainer.text['grouperLoaderFailsafeSendEmailLabel']}</label></strong></td>
+                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="editFailsafeSendEmailId">${textContainer.text['grouperLoaderFailsafeSendEmailLabel']}</label></strong></td>
                               <td>
                                 <span style="white-space: nowrap">
                                   <select name="editFailsafeSendEmailName" id="editFailsafeSendEmailId" style="width: 30em">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderOverall.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderOverall.jsp
@@ -53,7 +53,7 @@ ${grouper:title('loaderJobsPageTitle')}
 
                   <div class="row-fluid" style="margin-top: 0.5em">
                     <div class="span1">
-                      <label for="xxx">${textContainer.text['grouperLoaderOverallColumnHeaderStatus'] }:</label>
+                      <label for="loaderJobsStatusFilterId">${textContainer.text['grouperLoaderOverallColumnHeaderStatus'] }:</label>
                     </div>
                     <div class="span4" style="white-space: nowrap;">
                       <select name="loaderJobsStatusFilter" id="loaderJobsStatusFilterId">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderOverallContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/grouperLoaderOverallContents.jsp
@@ -93,7 +93,7 @@
             </td>
             <td class="expand foo-clicker">${guiGrouperLoaderJob.schedule}
             </td>
-            <td class="expand foo-clicker"><input type="text" readonly value="${grouper:escapeHtml(guiGrouperLoaderJob.query)}" style="cursor: text; background-color: #ffffff; width: 50em"/>
+            <td class="expand foo-clicker"><input type="text" readonly aria-label="${textContainer.textEscapeXml['grouperLoaderOverallColumnHeaderQuery']}" value="${grouper:escapeHtml(guiGrouperLoaderJob.query)}" style="cursor: text; background-color: #ffffff; width: 50em"/>
             </td>
         </tr>
         <c:set var="i" value="${i+1}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/newGroup.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/newGroup.jsp
@@ -19,7 +19,7 @@ ${grouper:title('newGroupPageTitle')}
                   </div>
                   <div class="modal-body">
                     <form class="form form-inline" id="stemSearchFormId">
-                      <input name="stemSearch" type="text" placeholder="${textContainer.textEscapeXml['groupCreateSearchPlaceholder'] }" value=""/> 
+                      <input name="stemSearch" type="text" aria-label="${textContainer.textEscapeXml['groupCreateSearchPlaceholder']}" placeholder="${textContainer.textEscapeXml['groupCreateSearchPlaceholder'] }" value=""/> 
                       <button class="btn" onclick="ajax('../app/UiV2Stem.stemSearchGroupFormSubmit?stemId=${grouperRequestContainer.stemContainer.guiStem.stem.id}', {formIds: 'stemSearchFormId'}); return false;">${textContainer.text['groupCreateSearchButton'] }</button>
                     </form>
                     <div id="folderSearchResultsId"></div>
@@ -60,7 +60,7 @@ ${grouper:title('newGroupPageTitle')}
                       </span>
                       <span style="white-space: nowrap;">
                         <label for="nameDifferentThanIdId" class="checkbox" style="display: inline-block;">
-                          <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true" style="float: none"
+                          <input type="checkbox" name="nameDifferentThanId" aria-label="${textContainer.textEscapeXml['groupNewEditTheId']}" id="nameDifferentThanIdId" value="true" style="float: none"
                             onchange="syncNameAndId('groupName', 'groupId', 'nameDifferentThanIdId', false, null); return true;"
                           />
                           ${textContainer.text['groupNewEditTheId'] }

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/ruleAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/ruleAddHelper.jsp
@@ -248,7 +248,7 @@
                           </tr>
                           
                          <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperRuleCheckOwnerStemScopeId">${textContainer.text['grouperRuleOwnerStemScopeLabel']}</label></strong></td>
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperRuleIfConditionOwnerStemScopeId">${textContainer.text['grouperRuleOwnerStemScopeLabel']}</label></strong></td>
                           <td>
                             
                             <select name="grouperRuleIfConditionOwnerStemScope" id="grouperRuleIfConditionOwnerStemScopeId" style="width: 30em" onchange="ajax('../app/UiV2Group.addRuleOnGroup', {formIds: 'addRuleConfigFormId'}); return false;">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsAttributeDefPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsAttributeDefPrivilegesContents.jsp
@@ -52,6 +52,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupPrivilegesInAttributeDefCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsGroupPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsGroupPrivilegesContents.jsp
@@ -52,6 +52,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupPrivilegesInOtherGropusCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsMemberships.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsMemberships.jsp
@@ -39,7 +39,7 @@ ${grouper:titleFromKeyAndText('groupMembershipsPageTitle', grouperRequestContain
                     </div>
                     <div class="span4">
                       <input type="text" placeholder="${textContainer.textEscapeXml['thisGroupsMembershipsFilterFormPlaceholder']}" 
-                         name="filterText" id="table-filter" class="span12"/>
+                         name="filterText" id="table-filter" aria-label="${textContainer.textEscapeXml['thisGroupsMembershipsFilterFormPlaceholder']}" class="span12"/>
                     </div>
 
                     <div class="span3"><input type="submit" class="btn" aria-controls="thisGroupsMembershipsFilterResultsId"  id="filterSubmitId" value="${textContainer.textEscapeDouble['groupApplyFilterButton'] }"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsMembershipsContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsMembershipsContents.jsp
@@ -15,6 +15,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupMembershipsInOtherGropusCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th data-hide="phone,medium">${textContainer.text['thisGroupsMembershipsFolderColumn'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsStemPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/thisGroupsStemPrivilegesContents.jsp
@@ -44,6 +44,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupPrivilegesInOtherFoldersCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/viewGroupMembers.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/viewGroupMembers.jsp
@@ -222,7 +222,7 @@ ${grouper:titleFromKeyAndText('groupPageTitle', grouperRequestContainer.groupCon
                           </select>
                         </div>
                         <div class="span3" id="groupFilterTextDiv">
-                          <input type="text" name="filterText" id="table-filter" class="span12"/>
+                          <input type="text" name="filterText" id="table-filter" aria-label="${textContainer.textEscapeXml['groupFilterMemberSearch']}" class="span12"/>
                         </div>
     
                         <div class="span4" id="groupFilterSubmitDiv"><input type="submit" class="btn" aria-controls="groupFilterResultsId" id="filterSubmitId" value="${textContainer.textEscapeDouble['groupApplyFilterButton'] }"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupAttribute/groupAttributeAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupAttribute/groupAttributeAssignAddMetadataAssignment.jsp
@@ -52,7 +52,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupAttribute/groupAttributeAssignmentSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupAttribute/groupAttributeAssignmentSection.jsp
@@ -17,7 +17,7 @@
           <form id="assignAttributeGroupForm" class="form-horizontal">
              <input type="hidden" name="groupId" value="${grouperRequestContainer.groupContainer.guiGroup.group.id}" />
              <div class="control-group">
-               <label class="control-label">${textContainer.text['groupAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['groupAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"
                    filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupImport/groupImport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupImport/groupImport.jsp
@@ -20,10 +20,10 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
               </div>
               <div class="modal-body">
                 <form class="form form-inline" id="addMemberSearchFormId">
-                  <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                  <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                   <button class="btn" onclick="ajax('../app/UiV2Group.addMemberSearch?groupId=${grouperRequestContainer.groupContainer.guiGroup.group.id}', {formIds: 'addMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                   <br />
-                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
                   <br />
                   <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                   <select name="sourceId">
@@ -56,10 +56,10 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="modal-body">
                 <form class="form form-inline" id="addGroupSearchFormId">
-                  <input id="addGroupSearchId" name="addGroupSearch" type="text" placeholder="${textContainer.text['groupImportSearchGroupPlaceholder']}" />
+                  <input id="addGroupSearchId" name="addGroupSearch" type="text" aria-label="${textContainer.textEscapeXml['groupImportSearchGroupPlaceholder']}" placeholder="${textContainer.text['groupImportSearchGroupPlaceholder']}" />
                   <button class="btn" onclick="ajax('../app/UiV2GroupImport.groupImportGroupSearch', {formIds: 'addGroupSearchFormId'}); return false;" >${textContainer.text['groupImportSearchButton'] }</button>
                   <br />
-                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['subjectSearchExactIdMatch'] }</span>
+                  <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['subjectSearchExactIdMatch']}"/> ${textContainer.text['subjectSearchExactIdMatch'] }</span>
                 </form>
                 <div id="addGroupResults">
                 </div>
@@ -105,7 +105,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="bulk-add-group-input-container">
                 <div class="control-group bulk-add-group-block">
-                  <label for="add-entities" style="position:absolute" class="control-label">${textContainer.text['groupImportAddMembersToGroupLabel'] }</label>
+                  <label for="groupImportGroupComboId" style="position:absolute" class="control-label">${textContainer.text['groupImportAddMembersToGroupLabel'] }</label>
                   <div class="controls">
                     <grouper:combobox2 idBase="groupImportGroupCombo" style="width: 30em" 
                        value="${grouperRequestContainer.groupContainer.guiGroup.group.id}"
@@ -132,7 +132,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="bulk-add-group-list-container hide">
                 <div class="control-group">
-                  <label for="groupList" class="control-label">${textContainer.text['groupImportEnterListOfGroupNamesOrIds'] }</label>
+                  <label for="groupListId" class="control-label">${textContainer.text['groupImportEnterListOfGroupNamesOrIds'] }</label>
                   <div class="controls">
                     <textarea rows="10" name="groupList" id="groupListId"></textarea>
                     <br /><br />
@@ -145,7 +145,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="bulk-add-group-import-container hide">
                 <div class="control-group">
-                  <label class="control-label">${textContainer.text['groupImportSelectGroupFileToImport'] }</label>
+                  <label class="control-label" for="importGroupCsvFileId">${textContainer.text['groupImportSelectGroupFileToImport'] }</label>
                   <div class="controls">
                     <input type="file" name="importGroupCsvFile" id="importGroupCsvFileId"><span class="help-block">
                     ${textContainer.text['groupImportSelectGroupFileDescription']}
@@ -178,7 +178,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="bulk-add-input-container">
                 <div class="control-group bulk-add-block">
-                  <label for="add-entities" class="control-label">${textContainer.text['groupImportEnterMemberNameOrId'] }</label>
+                  <label for="groupAddMemberComboId" class="control-label">${textContainer.text['groupImportEnterMemberNameOrId'] }</label>
                   <div class="controls">
                     <grouper:combobox2 idBase="groupAddMemberCombo" style="width: 30em" 
                        value="${grouperRequestContainer.groupImportContainer.importDefaultSubject}"
@@ -208,7 +208,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
               
               <div class="bulk-add-import-container hide">
                 <div class="control-group">
-                  <label class="control-label">${textContainer.text['groupImportSelectFileToImport'] }</label>
+                  <label class="control-label" for="importCsvFileId">${textContainer.text['groupImportSelectFileToImport'] }</label>
                   <div class="controls">
                     <input type="file" name="importCsvFile" id="importCsvFileId"><span class="help-block">
                     
@@ -244,7 +244,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
 
               <div class="bulk-add-list-container hide">
                 <div class="control-group">
-                  <label for="add-entities" class="control-label">${textContainer.text['groupImportEnterListOfMemberIds'] }</label>
+                  <label for="entityListId" class="control-label">${textContainer.text['groupImportEnterListOfMemberIds'] }</label>
                   <div class="controls">
                     <textarea rows="10" name="entityList" id="entityListId"></textarea>
                     <span class="help-block">${textContainer.text['groupImportEnterListOfMemberIdsHelp'] }</span>
@@ -255,7 +255,7 @@ ${grouper:titleFromKeyAndText('groupImportPageTitle', grouperRequestContainer.gr
                   </div>
                 </div>
                 <div class="control-group">
-                  <label for="searchEntitiesSource" class="control-label">${textContainer.text['find.search-source'] }</label>
+                  <label for="searchEntitySourceId" class="control-label">${textContainer.text['find.search-source'] }</label>
                   <div class="controls">
                     <select name="searchEntitySourceName" id="searchEntitySourceId">
                       <option value="all">${textContainer.textEscapeXml['find.search-all-sources'] }</option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupPermissions/groupAssignPermission.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupPermissions/groupAssignPermission.jsp
@@ -11,7 +11,7 @@
                   <input type="hidden" name="groupId" value="${grouperRequestContainer.permissionContainer.guiGroup.group.id}" />
                   
                   <div class="control-group">
-                    <label class="control-label">${textContainer.text['groupAssignPermissionPermissionDefLabel'] }</label>
+                    <label for="permissionDefComboId" class="control-label">${textContainer.text['groupAssignPermissionPermissionDefLabel'] }</label>
                     <div class="controls">
                       <input type="hidden" name="attributeDefType" value="perm" /> 	                    	
                       <grouper:combobox2 idBase="permissionDefCombo" style="width: 30em"
@@ -23,7 +23,7 @@
                     </div>
                   </div>
                   <div class="control-group">
-                    <label class="control-label">${textContainer.text['groupAssignPermissionResourceLabel'] }</label>
+                    <label for="permissionResourceNameComboId" class="control-label">${textContainer.text['groupAssignPermissionResourceLabel'] }</label>
                     <div class="controls">
                     	                    	
                       <grouper:combobox2 idBase="permissionResourceNameCombo" style="width: 30em"
@@ -36,7 +36,7 @@
                   </div>
                   
                   <div class="control-group">
-                    <label class="control-label">${textContainer.text['groupAssignPermissionActionLabel'] }</label>
+                    <label for="permissionActionComboId" class="control-label">${textContainer.text['groupAssignPermissionActionLabel'] }</label>
                     <div class="controls">
                     	                    	
                       <grouper:combobox2 idBase="permissionActionCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupPermissions/groupPermissionAddLimit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupPermissions/groupPermissionAddLimit.jsp
@@ -34,7 +34,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label">${textContainer.text['simplePermissionUpdate.addLimitDefinition'] }</label>
+        <label for="limitDefComboId" class="control-label">${textContainer.text['simplePermissionUpdate.addLimitDefinition'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeDefType" value="limit" /> 	                    	
           <grouper:combobox2 idBase="limitDefCombo" style="width: 30em"
@@ -45,7 +45,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label">${textContainer.text['simplePermissionUpdate.addLimitName'] }</label>
+        <label for="limitResourceNameComboId" class="control-label">${textContainer.text['simplePermissionUpdate.addLimitName'] }</label>
         <div class="controls">
           <grouper:combobox2 idBase="limitResourceNameCombo" style="width: 30em"
             filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/grouperReport/reportConfigObjectAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/grouperReport/reportConfigObjectAddHelper.jsp
@@ -110,7 +110,7 @@
                         </tr>
                         
                         <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigViewersGroupIdId">${textContainer.text['grouperReportConfigViewersGroupIdLabel']}</label></strong></td>
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigViewersGroupComboId">${textContainer.text['grouperReportConfigViewersGroupIdLabel']}</label></strong></td>
                           <td>
 				                    <grouper:combobox2 idBase="grouperReportConfigViewersGroupCombo" style="width: 30em" 
 				                       value="${grouperRequestContainer.grouperReportContainer.configBean.reportConfigViewersGroupId}"
@@ -184,7 +184,7 @@
                           <c:if test="${grouperRequestContainer.grouperReportContainer.configBean.reportConfigSendEmailToViewers == false}">
                           
 	                          <tr>
-		                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigSendEmailToGroupIdId">${textContainer.text['grouperReportConfigSendEmailToGroupIdLabel']}</label></strong></td>
+		                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigSendEmailToGroupComboId">${textContainer.text['grouperReportConfigSendEmailToGroupIdLabel']}</label></strong></td>
 		                          <td>
 		                             <table cellspacing="0" cellpadding="0" border="0">
                                   <tr>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/grouperReport/reportConfigObjectEditHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/grouperReport/reportConfigObjectEditHelper.jsp
@@ -123,7 +123,7 @@
                         </tr>
                         
                         <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigViewersGroupIdId">${textContainer.text['grouperReportConfigViewersGroupIdLabel']}</label></strong></td>
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigViewersGroupComboId">${textContainer.text['grouperReportConfigViewersGroupIdLabel']}</label></strong></td>
                           <td>
                             <grouper:combobox2 idBase="grouperReportConfigViewersGroupCombo" style="width: 30em" 
                                    value="${grouperRequestContainer.grouperReportContainer.configBean.reportConfigViewersGroupId}"
@@ -196,7 +196,7 @@
                           <c:if test="${grouperRequestContainer.grouperReportContainer.configBean.reportConfigSendEmailToViewers == false}">
                           
                             <tr>
-                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigSendEmailToGroupIdId">${textContainer.text['grouperReportConfigSendEmailToGroupIdLabel']}</label></strong></td>
+                              <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperReportConfigSendEmailToGroupComboId">${textContainer.text['grouperReportConfigSendEmailToGroupIdLabel']}</label></strong></td>
                               <td>
                               
                                 <grouper:combobox2 idBase="grouperReportConfigSendEmailToGroupCombo" style="width: 30em" 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/gshTemplateConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/gshTemplateConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.gshTemplateContainer.guiGshTemplateConfiguration}" var="guiGshTemplateConfiguration"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="gshTemplateConfigId">${textContainer.text['gshTemplateConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="configId">${textContainer.text['gshTemplateConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
     	

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/index/search.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/index/search.jsp
@@ -18,7 +18,7 @@
                     onsubmit="return guiV2link('operation=UiV2Main.searchSubmit', {optionalFormElementNamesToSend: 'searchQuery,filterType'});">
                   <div class="row-fluid">
                     <div class="span2">
-                      <label for="searchFormSearch">${textContainer.text['find.search-for'] }</label>
+                      <label for="searchQueryId">${textContainer.text['find.search-for'] }</label>
                     </div>
                     <div class="span3" style="white-space: nowrap;">
                       <input type="text" name="searchQuery" id="searchQueryId" value="${grouper:escapeHtml(grouperRequestContainer.indexContainer.searchQuery) }" style="width: 25em" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityPrivilegeContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityPrivilegeContents.jsp
@@ -42,6 +42,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['groupViewDetailsPrivilegesCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th class="sorted" style="width: 35em">Entity name</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityWsJwtKeySection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityWsJwtKeySection.jsp
@@ -15,7 +15,7 @@
           <%-- <form id="wsJwtKeyCreateDownloadForm" class="form-horizontal">
              <input type="hidden" name="subjectId" value="${grouperRequestContainer.subjectContainer.guiSubject.subject.id}" />
              <div class="control-group">
-               <label class="control-label">${textContainer.text['subjectAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['subjectAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"
                    filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/newLocalEntity.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/newLocalEntity.jsp
@@ -18,7 +18,7 @@ ${grouper:title('newLocalEntityPageTitle')}
                   </div>
                   <div class="modal-body">
                     <form class="form form-inline" id="stemSearchFormId">
-                      <input name="stemSearch" type="text" placeholder="${textContainer.textEscapeXml['groupCreateSearchPlaceholder'] }" value=""/> 
+                      <input name="stemSearch" type="text" aria-label="${textContainer.textEscapeXml['groupCreateSearchPlaceholder']}" placeholder="${textContainer.textEscapeXml['groupCreateSearchPlaceholder'] }" value=""/> 
                       <button class="btn" onclick="ajax('../app/UiV2Stem.stemSearchGroupFormSubmit?stemId=${grouperRequestContainer.stemContainer.guiStem.stem.id}', {formIds: 'stemSearchFormId'}); return false;">${textContainer.text['groupCreateSearchButton'] }</button>
                     </form>
                     <div id="folderSearchResultsId"></div>
@@ -30,7 +30,7 @@ ${grouper:title('newLocalEntityPageTitle')}
                 </div>
                 <form id="addGroupForm" class="form-horizontal">
                   <div class="control-group">
-                    <label for="folder-path" class="control-label">${textContainer.text['groupCreateFolderLabel'] }</label>
+                    <label for="parentFolderComboId" class="control-label">${textContainer.text['groupCreateFolderLabel'] }</label>
                     <div class="controls">
                       <%-- placeholder: Enter a folder name --%>
                       <grouper:combobox2 idBase="parentFolderCombo" style="width: 30em" 
@@ -57,7 +57,7 @@ ${grouper:title('newLocalEntityPageTitle')}
                         <input type="text" id="groupId" name="extension" disabled="disabled"  /> 
                       </span>
                       <span style="white-space: nowrap;">
-                        <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true"
+                        <input type="checkbox" name="nameDifferentThanId" aria-label="${textContainer.textEscapeXml['groupNewEditTheId']}" id="nameDifferentThanIdId" value="true"
                           onchange="syncNameAndId('groupName', 'groupId', 'nameDifferentThanIdId', false, null); return true;"
                         /> ${textContainer.text['groupNewEditTheId'] }
                       </span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membershipAttribute/membershipAttributeAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membershipAttribute/membershipAttributeAssignAddMetadataAssignment.jsp
@@ -58,7 +58,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membershipAttribute/membershipAttributeAssignmentSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membershipAttribute/membershipAttributeAssignmentSection.jsp
@@ -38,7 +38,7 @@
              </div>
              
              <div class="control-group">
-               <label class="control-label">${textContainer.text['membershipAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['membershipAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                                        
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStems.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStems.jsp
@@ -39,7 +39,7 @@ ${grouper:title('myStemsPageTitle')}
                       
                     </div>
                     <div class="span3"  style="white-space: nowrap;">
-                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" class="span12"/>
+                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" aria-label="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder']}" class="span12"/>
                     </div>
                     <div class="span3"> &nbsp; &nbsp;
                       <button type="submit" class="btn" aria-controls="myStemsResultsId" onclick="ajax('../app/UiV2MyStems.myStemsSubmit', {formIds: 'myStemsPagingFormId,myStemsForm'}); return false;">${textContainer.text['myStemsApplyFilterButton'] }</button>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingAttributesImanage.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingAttributesImanage.jsp
@@ -37,7 +37,7 @@
                       
                     </div>
                     <div class="span3"  style="white-space: nowrap;">
-                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" class="span12"/>
+                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" aria-label="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder']}" class="span12"/>
                     </div>
                     <div class="span3"> &nbsp; &nbsp;
                       <button type="submit" class="btn" aria-controls="myStemsResultsId" onclick="ajax('../app/UiV2MyStems.myStemsContainingAttributesImanageSubmit', {formIds: 'myStemsPagingFormId,myStemsForm'}); return false;">${textContainer.text['myStemsApplyFilterButton'] }</button>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingGroupsImanage.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingGroupsImanage.jsp
@@ -37,7 +37,7 @@
                       
                     </div>
                     <div class="span3"  style="white-space: nowrap;">
-                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" class="span12"/>
+                      <input type="text" name="myStemsFilter" placeholder="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder'] }" id="myStemsFilterId" aria-label="${textContainer.textEscapeXml['myStemsSearchNamePlaceholder']}" class="span12"/>
                     </div>
                     <div class="span3"> &nbsp; &nbsp;
                       <button type="submit" class="btn" aria-controls="myStemsResultsId" onclick="ajax('../app/UiV2MyStems.myStemsContainingGroupsImanageSubmit', {formIds: 'myStemsPagingFormId,myStemsForm'}); return false;">${textContainer.text['myStemsApplyFilterButton'] }</button>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigRunFullSync.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigRunFullSync.jsp
@@ -39,7 +39,7 @@
 				</tr>
 				
 				<tr>
-				  <td style="vertical-align: top; white-space: nowrap;"><strong><label>${textContainer.text['provisionerConfigSynchronous']}</label></strong></td>
+				  <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisionerConfigSynchoronousId">${textContainer.text['provisionerConfigSynchronous']}</label></strong></td>
 				    <td>
                        <select name="provisionerConfigSynchoronous" id="provisionerConfigSynchoronousId" style="width: 30em">
                          <option value="false">${textContainer.textEscapeXml['provisionerConfigSynchronousYesOption']}</option>
@@ -51,7 +51,7 @@
 				</tr>
 				
 				<tr>
-				  <td style="vertical-align: top; white-space: nowrap;"><strong><label>${textContainer.text['provisionerConfigReadOnly']}</label></strong></td>
+				  <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisionerConfigReadOnlyId">${textContainer.text['provisionerConfigReadOnly']}</label></strong></td>
 				    <td>
                        <select name="provisionerConfigReadOnly" id="provisionerConfigReadOnlyId" style="width: 30em">
                          <option value="false">${textContainer.textEscapeXml['provisionerConfigReadOnlyNoOption']}</option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewErrors.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewErrors.jsp
@@ -61,7 +61,7 @@
 				</tr>
         
         <tr>
-          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisionerConfigErrorTypeId">${textContainer.text['provisionerConfigErrorType']}</label></strong></td>
+          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisionerErrorTypeId">${textContainer.text['provisionerConfigErrorType']}</label></strong></td>
             <td>
                <select name="provisionerConfigErrorType" id="provisionerErrorTypeId" style="width: 30em">
                 <option value=""></option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisioning/provisioningObjectSettingsEditHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisioning/provisioningObjectSettingsEditHelper.jsp
@@ -25,7 +25,7 @@
                       <%-- if the target is selected --%>
                       <c:if test="${!grouper:isBlank(grouperRequestContainer.provisioningContainer.targetName)}">
                         <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperObjectTypeHasConfigurationId">${textContainer.text['provisioningDirectIndirectTypeLabel']}</label></strong></td>
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisioningHasConfigurationId">${textContainer.text['provisioningDirectIndirectTypeLabel']}</label></strong></td>
                           <td>
                             <select name="provisioningHasConfigurationName" id="provisioningHasConfigurationId" style="width: 30em"
                               onchange="ajax('../app/UiV2Provisioning.editProvisioningOn${ObjectType}', {formIds: 'editProvisioningFormId'}); return false;">
@@ -42,7 +42,7 @@
                         <c:if test="${grouperRequestContainer.provisioningContainer.grouperProvisioningAttributeValue.directAssignment}">
                         
                           <tr>
-                            <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperDeprovisioningDeprovisionId">${textContainer.text['provisioningProvisionLabel']}</label></strong></td>
+                            <td style="vertical-align: top; white-space: nowrap;"><strong><label for="provisioningProvisionId">${textContainer.text['provisioningProvisionLabel']}</label></strong></td>
                             <td>
                               <select name="provisioningProvisionName" id="provisioningProvisionId" style="width: 30em"
                                 onchange="ajax('../app/UiV2Provisioning.editProvisioningOn${ObjectType}', {formIds: 'editProvisioningFormId'}); return false;">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/groupMembershipsInFolder.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/groupMembershipsInFolder.jsp
@@ -156,7 +156,7 @@ ${grouper:titleFromKeyAndText('groupMembershipsInFolderPageTitle', grouperReques
                     </div>
                     <div class="span3" id="groupFilterTextDiv">
                       <input type="text" placeholder="${textContainer.textEscapeXml['groupFilterFormPlaceholder']}" 
-                         name="filterText" id="table-filter" class="span12"/>
+                         name="filterText" id="table-filter" aria-label="${textContainer.textEscapeXml['groupFilterFormPlaceholder']}" class="span12"/>
                     </div>
     
                     <div class="span4" id="groupFilterSubmitDiv"><input type="submit" class="btn btn-primary" aria-controls="groupFilterResultsId" id="filterSubmitId" value="${textContainer.textEscapeDouble['groupApplyFilterButton'] }"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/groupMembershipsInFolderContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/groupMembershipsInFolderContents.jsp
@@ -15,6 +15,7 @@
                           <c:if test="${!grouperRequestContainer.stemContainer.showPointInTimeAudit}">
                             <label class="checkbox checkbox-no-padding">
                               <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                              <span class="sr-only">${textContainer.text['groupViewDetailsMembershipCheckboxAriaLabel']}</span>
                             </label>
                           </c:if>
                         </th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/newStem.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/newStem.jsp
@@ -19,7 +19,7 @@ ${grouper:title('newStemPageTitle')}
                   </div>
                   <div class="modal-body">
                     <form class="form form-inline" id="stemSearchFormId">
-                      <input name="stemSearch" type="text" placeholder="${textContainer.textEscapeXml['stemCreateSearchPlaceholder'] }" value=""/> 
+                      <input name="stemSearch" type="text" aria-label="${textContainer.textEscapeXml['stemCreateSearchPlaceholder']}" placeholder="${textContainer.textEscapeXml['stemCreateSearchPlaceholder'] }" value=""/> 
                       <button class="btn" onclick="ajax('../app/UiV2Stem.stemSearchFormSubmit?stemId=${grouperRequestContainer.stemContainer.guiStem.stem.id}', {formIds: 'stemSearchFormId'}); return false;">${textContainer.text['stemCreateSearchButton'] }</button>
                     </form>
                     <div id="folderSearchResultsId"></div>
@@ -31,7 +31,7 @@ ${grouper:title('newStemPageTitle')}
                 </div>
                 <form id="addStemForm" class="form-horizontal">
                   <div class="control-group">
-                    <label for="folder-path" class="control-label">${textContainer.text['stemCreateFolderLabel'] }</label>
+                    <label for="parentFolderComboId" class="control-label">${textContainer.text['stemCreateFolderLabel'] }</label>
                     <div class="controls">
                       <%-- placeholder: Enter a folder name --%>
                       <grouper:combobox2 idBase="parentFolderCombo" style="width: 30em" 
@@ -58,7 +58,7 @@ ${grouper:title('newStemPageTitle')}
                         <input type="text" id="stemId" name="extension" disabled="disabled"  /> 
                       </span>
                       <span style="white-space: nowrap;">
-                        <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true"
+                        <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true" aria-label="${textContainer.textEscapeXml['stemNewEditTheId']}"
                           onchange="syncNameAndId('stemName', 'stemId', 'nameDifferentThanIdId', false, null); return true;"
                         />
                         ${textContainer.text['stemNewEditTheId'] }

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/privilegesInheritedContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/privilegesInheritedContents.jsp
@@ -22,6 +22,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['ariaLabelGuiSelectAll']}</span>
                         </label>
                       </th>
                       <th data-hide="phone" style="white-space: nowrap; text-align: left;">${textContainer.text['stemPrivilegesInheritColumnHeaderStemName'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/ruleAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/ruleAddHelper.jsp
@@ -318,7 +318,7 @@
                         </c:if>
                         
                          <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperRuleCheckOwnerStemScopeId">${textContainer.text['grouperRuleOwnerStemScopeLabel']}</label></strong></td>
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperRuleIfConditionOwnerStemScopeId">${textContainer.text['grouperRuleOwnerStemScopeLabel']}</label></strong></td>
                           <td>
                             
                             <select name="grouperRuleIfConditionOwnerStemScope" id="grouperRuleIfConditionOwnerStemScopeId" style="width: 30em" onchange="ajax('../app/UiV2Stem.addRuleOnStem', {formIds: 'addRuleConfigFormId'}); return false;">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemAttestationEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemAttestationEdit.jsp
@@ -70,7 +70,7 @@
 
         <tr>
           <td style="vertical-align: top; white-space: nowrap;"><strong><label
-              for="grouperAttestationAuthorizedGroupId">${textContainer.text['attestationAuthorizedGroupLabel']}</label></strong></td>
+              for="grouperAttestationAuthorizedGroupComboId">${textContainer.text['attestationAuthorizedGroupLabel']}</label></strong></td>
           <td id="grouperAttestationAuthorizedGroupComboTd">
             <style>#grouperAttestationAuthorizedGroupComboTd td {padding: 0; border: 0}</style>
           

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemDelete.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemDelete.jsp
@@ -77,7 +77,7 @@ ${grouper:titleFromKeyAndText('stemDeletePageTitle', grouperRequestContainer.ste
                     <table class="table table-condensed table-striped">
                       <tbody>
                         <tr>
-                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="stemObliterateId"
+                          <td style="vertical-align: top; white-space: nowrap;"><strong><label for="stemObliterateNameId"
                             >${textContainer.text['stemDeleteObliterateLabel']}</label></strong></td>
                           <td>
                             <select name="stemObliterateName" id="stemObliterateNameId" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemHeader.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemHeader.jsp
@@ -13,10 +13,10 @@
                       </div>
                       <div class="modal-body">
                         <form class="form form-inline" id="addMemberSearchFormId">
-                          <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                          <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                           <button class="btn" onclick="ajax('../app/UiV2Stem.addMemberSearch?stemId=${grouperRequestContainer.stemContainer.guiStem.stem.id}', {formIds: 'addMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['stemLabelExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['stemLabelExactIdMatch']}"/> ${textContainer.text['stemLabelExactIdMatch'] }</span>
                           <br />
                           <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                           <select name="sourceId">
@@ -44,7 +44,7 @@
                       <div id="add-members">
                         <form id="add-members-form" target="#" class="form-horizontal form-highlight">
                           <div class="control-group">
-                            <label for="add-block-input" class="control-label">${textContainer.text['stemSearchMemberOrId'] }</label>
+                            <label for="groupAddMemberComboId" class="control-label">${textContainer.text['stemSearchMemberOrId'] }</label>
                             <div class="controls">
                               <div id="add-members-container">
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemNewTemplate.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemNewTemplate.jsp
@@ -79,7 +79,7 @@
 	               name="serviceFriendlyName" id="serviceFriendlyNameId" disabled="disabled" />
 	          </span>
 	          <span style="white-space: nowrap;">
-	            <input type="checkbox" name="nameDifferentThanId" id="nameDifferentThanIdId" value="true"
+	            <input type="checkbox" name="nameDifferentThanId" aria-label="${textContainer.textEscapeXml['stemServiceEditFriendlyName']}" id="nameDifferentThanIdId" value="true"
 	              onchange="syncNameAndId('serviceKeyId', 'serviceFriendlyNameId', 'nameDifferentThanIdId', false, null); return true;"
 	            /> ${textContainer.text['stemServiceEditFriendlyName'] }
 	          </span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemPrivilegeContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemPrivilegeContents.jsp
@@ -36,8 +36,9 @@
                     <tr>
                       <th>
                         <label class="checkbox checkbox-no-padding">
-                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" aria-label="${textContainer.text['stemPrivilegesCheckboxAriaLabel'] }"
+                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId"
                            onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['stemPrivilegesCheckboxAriaLabel'] }</span>
                         </label>
                       </th>
                       <th class="sorted">${textContainer.text['privDropdownName'] }</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemViewAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemViewAudits.jsp
@@ -25,9 +25,9 @@ ${grouper:titleFromKeyAndText('stemAuditsPageTitle', grouperRequestContainer.ste
                     <option value="between">${textContainer.text['groupAuditLogFilterType_between']}</option>
                     <option value="since">${textContainer.text['groupAuditLogFilterType_since']}</option>
                   </select>
-                  <input id="from-date" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="from-date" aria-label="${textContainer.text['ariaLabelGuiFromDate']}" name="filterFromDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;( ${textContainer.text['groupAuditLogFilterAndLabel'] }&nbsp;
-                  <input id="to-date" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
+                  <input id="to-date" aria-label="${textContainer.text['ariaLabelGuiToDate']}" name="filterToDate" type="text" placeholder="${textContainer.text['groupAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;)
                   <label class="checkbox">
                     <input type="checkbox" name="showExtendedResults" value="true">${textContainer.text['groupAuditLogFilterShowExtendedResults']}

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemViewHistoryChart.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemViewHistoryChart.jsp
@@ -46,7 +46,7 @@ ${grouper:titleFromKeyAndText('groupHistoryChartPageTitle', grouperRequestContai
 
                             <input type="text" name="dateFromRelative" id="dateFromRelativeId" class="span3" placeholder="${textContainer.text['groupHistoryChartRelativeScalePlaceholder'] }">
 
-                            <select name="dateFromRelativeScale" id="dateFromRelativeScale" class="span4">
+                            <select name="dateFromRelativeScale" id="dateFromRelativeScale" aria-label="${textContainer.textEscapeXml['groupHistoryChartRelativeScalePlaceholder']}" class="span4">
                               <option value="years" selected>${textContainer.text['groupHistoryChartRelativeScaleYears'] }</option>
                               <option value="months">${textContainer.text['groupHistoryChartRelativeScaleMonths'] }</option>
                               <option value="days" selected>${textContainer.text['groupHistoryChartRelativeScaleDays'] }</option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stemAttribute/stemAttributeAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stemAttribute/stemAttributeAssignAddMetadataAssignment.jsp
@@ -52,7 +52,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stemAttribute/stemAttributeAssignmentSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stemAttribute/stemAttributeAssignmentSection.jsp
@@ -17,7 +17,7 @@
           <form id="assignAttributeStemForm" class="form-horizontal">
              <input type="hidden" name="stemId" value="${grouperRequestContainer.stemContainer.guiStem.stem.id}" />
              <div class="control-group">
-               <label class="control-label">${textContainer.text['stemAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['stemAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                                        
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectContents.jsp
@@ -9,6 +9,7 @@
                       <th>
                         <label class="checkbox checkbox-no-padding">
                           <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.membershipCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['ariaLabelGuiSelectAll']}</span>
                         </label>
                       </th>
                       <th data-hide="phone,medium">${textContainer.text['subjectMembershipStemColumn']}</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectHeader.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectHeader.jsp
@@ -18,10 +18,10 @@
                       </div>
                       <div class="modal-body">
                         <form class="form form-inline" id="addMemberSearchFormId">
-                          <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+                          <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
                           <button class="btn" onclick="ajax('../app/UiV2Group.addMemberSearch?groupId=${grouperRequestContainer.groupContainer.guiGroup.group.id}', {formIds: 'addMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
                           <br />
                           <span style="white-space: nowrap;">${textContainer.text['find.search-source'] } 
                           <select name="sourceId">
@@ -114,7 +114,7 @@
                           <input id="addGroupSubjectSearchId" name="addGroupSubjectSearch" type="text" placeholder="${textContainer.text['subjectSearchGroupPlaceholder']}" />
                           <button class="btn" onclick="ajax('../app/UiV2Subject.addGroupSearch?subjectId=${grouperRequestContainer.subjectContainer.guiSubject.subject.id}&sourceId=${grouperRequestContainer.subjectContainer.guiSubject.subject.sourceId}', {formIds: 'addGroupSearchFormId'}); return false;" >${textContainer.text['subjectSearchButton'] }</button>
                           <br />
-                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['subjectSearchExactIdMatch'] }</span>
+                          <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['subjectSearchExactIdMatch']}"/> ${textContainer.text['subjectSearchExactIdMatch'] }</span>
                         </form>
                         <div id="addGroupResults">
                         </div>
@@ -128,7 +128,7 @@
                       <div id="add-groups">
                         <form id="add-groups-form" target="#" class="form-horizontal form-highlight">
                           <div class="control-group">
-                            <label for="add-block-input" class="control-label">${textContainer.text['subjectSearchGroupName'] }</label>
+                            <label for="groupAddMemberComboId" class="control-label">${textContainer.text['subjectSearchGroupName'] }</label>
                             <div class="controls">
                               <div id="add-members-container">
 
@@ -237,7 +237,7 @@
                       <div id="add-stems">
                         <form id="add-stems-form" target="#" class="form-horizontal form-highlight">
                           <div class="control-group">
-                            <label for="add-block-stem-input" class="control-label">${textContainer.text['subjectSearchStemName'] }</label>
+                            <label for="parentFolderComboId" class="control-label">${textContainer.text['subjectSearchStemName'] }</label>
                             <div class="controls">
                               <div id="add-stems-container">
 
@@ -301,7 +301,7 @@
                       <div id="add-attributeDefs">
                         <form id="add-attributeDefs-form" target="#" class="form-horizontal form-highlight">
                           <div class="control-group">
-                            <label for="add-block-input" class="control-label">${textContainer.text['subjectSearchAttributeDefName'] }</label>
+                            <label for="attributeDefAddMemberComboId" class="control-label">${textContainer.text['subjectSearchAttributeDefName'] }</label>
                             <div class="controls">
                               <div id="add-attributeDefs-container">
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectViewAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/subjectViewAudits.jsp
@@ -22,9 +22,9 @@ ${grouper:titleFromKeyAndText('subjectViewAuditsPageTitle', grouperRequestContai
                     <option value="between">${textContainer.text['subjectAuditLogFilterType_between']}</option>
                     <option value="since">${textContainer.text['subjectAuditLogFilterType_since']}</option>
                   </select>
-                  <input id="from-date" name="filterFromDate" type="text" placeholder="${textContainer.text['subjectAuditLogFilterDatePlaceholder'] }" 
+                  <input id="from-date" aria-label="${textContainer.text['ariaLabelGuiFromDate']}" name="filterFromDate" type="text" placeholder="${textContainer.text['subjectAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;( ${textContainer.text['subjectAuditLogFilterAndLabel'] }&nbsp;
-                  <input id="to-date" name="filterToDate" type="text" placeholder="${textContainer.text['subjectAuditLogFilterDatePlaceholder'] }" 
+                  <input id="to-date" aria-label="${textContainer.text['ariaLabelGuiToDate']}" name="filterToDate" type="text" placeholder="${textContainer.text['subjectAuditLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;)
                   <label class="checkbox">
                     <input type="checkbox" name="showExtendedResults" value="true">${textContainer.text['subjectAuditLogFilterShowExtendedResults']}

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsAttributeDefPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsAttributeDefPrivilegesContents.jsp
@@ -46,8 +46,9 @@
                     <tr>
                       <th>
                         <label class="checkbox checkbox-no-padding">
-                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" aria-label="${textContainer.text['subjectPrivilegesInAttributeDefCheckboxAriaLabel']}"
+                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId"
                            onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['subjectPrivilegesInAttributeDefCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsGroupPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsGroupPrivilegesContents.jsp
@@ -51,8 +51,9 @@
                     <tr>
                       <th>
                         <label class="checkbox checkbox-no-padding">
-                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" aria-label="${textContainer.text['subjectPrivilegesInGroupCheckboxAriaLabel']}"
+                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId"
                            onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['subjectPrivilegesInGroupCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsStemPrivilegesContents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/thisSubjectsStemPrivilegesContents.jsp
@@ -38,8 +38,9 @@
                     <tr>
                       <th>
                         <label class="checkbox checkbox-no-padding">
-                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" aria-label="${textContainer.text['subjectPrivilegesInFolderCheckboxAriaLabel']}"
+                          <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId"
                            onchange="$('.privilegeCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                          <span class="sr-only">${textContainer.text['subjectPrivilegesInFolderCheckboxAriaLabel']}</span>
                         </label>
                       </th>
                       <th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subject/viewSubject.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subject/viewSubject.jsp
@@ -33,7 +33,7 @@ ${grouper:titleFromKeyAndText('viewSubjectPageTitle', grouperRequestContainer.su
                     </div>
                     <div class="span4">
                       <input type="text" placeholder="${textContainer.textEscapeXml['subjectFilterFormPlaceholder']}" 
-                         name="filterText" id="table-filter" class="span12"/>
+                         name="filterText" id="table-filter" aria-label="${textContainer.textEscapeXml['subjectFilterFormPlaceholder']}" class="span12"/>
                     </div>
 
                     <div class="span3"><input type="submit" aria-controls="subjectFilterResultsId" class="btn"  id="filterSubmitId" value="${textContainer.textEscapeDouble['subjectApplyFilterButton'] }"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectAttribute/subjectAttributeAssignAddMetadataAssignment.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectAttribute/subjectAttributeAssignAddMetadataAssignment.jsp
@@ -49,7 +49,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
+        <label for="attributeAssignAssignAttributeComboId" class="control-label no-padding">${textContainer.text['simpleAttributeAssign.attributeName'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeAssignType" value="${attributeUpdateRequestContainer.attributeAssignType.assignmentOnAssignmentType}" />
           <grouper:combobox2 idBase="attributeAssignAssignAttributeCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectAttribute/subjectAttributeAssignmentSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectAttribute/subjectAttributeAssignmentSection.jsp
@@ -15,7 +15,7 @@
           <form id="assignAttributeSubjectForm" class="form-horizontal">
              <input type="hidden" name="subjectId" value="${grouperRequestContainer.subjectContainer.guiSubject.subject.id}" />
              <div class="control-group">
-               <label class="control-label">${textContainer.text['subjectAssignAttributeAttributeDefNameLabel'] }</label>
+               <label for="attributeDefNameComboId" class="control-label">${textContainer.text['subjectAssignAttributeAttributeDefNameLabel'] }</label>
                <div class="controls">
                  <grouper:combobox2 idBase="attributeDefNameCombo" style="width: 30em"
                    filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectPermissions/permissionAddLimit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectPermissions/permissionAddLimit.jsp
@@ -36,7 +36,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label">${textContainer.text['simplePermissionUpdate.addLimitDefinition'] }</label>
+        <label for="limitDefComboId" class="control-label">${textContainer.text['simplePermissionUpdate.addLimitDefinition'] }</label>
         <div class="controls">
           <input type="hidden" name="attributeDefType" value="limit" /> 	                    	
           <grouper:combobox2 idBase="limitDefCombo" style="width: 30em"
@@ -47,7 +47,7 @@
       </div>
       
       <div class="control-group">
-        <label class="control-label">${textContainer.text['simplePermissionUpdate.addLimitName'] }</label>
+        <label for="limitResourceNameComboId" class="control-label">${textContainer.text['simplePermissionUpdate.addLimitName'] }</label>
         <div class="controls">
           <grouper:combobox2 idBase="limitResourceNameCombo" style="width: 30em"
             filterOperation="UiV2AttributeDefName.attributeDefNameFilter"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectPermissions/subjectPermissionSection.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectPermissions/subjectPermissionSection.jsp
@@ -16,7 +16,7 @@
             <input type="hidden" name="memberId" value="${grouperRequestContainer.permissionContainer.guiMember.member.id}" />
           
           <div class="control-group">
-            <label class="control-label">${textContainer.text['subjectAssignPermissionPermissionDefLabel'] }</label>
+            <label for="permissionDefComboId" class="control-label">${textContainer.text['subjectAssignPermissionPermissionDefLabel'] }</label>
             <div class="controls">
               <input type="hidden" name="attributeDefType" value="perm" /> 	                    	
               <grouper:combobox2 idBase="permissionDefCombo" style="width: 30em"
@@ -28,7 +28,7 @@
             </div>
           </div>
           <div class="control-group">
-            <label class="control-label">${textContainer.text['subjectAssignPermissionResourceLabel'] }</label>
+            <label for="permissionResourceNameComboId" class="control-label">${textContainer.text['subjectAssignPermissionResourceLabel'] }</label>
             <div class="controls">
             	                    	
               <grouper:combobox2 idBase="permissionResourceNameCombo" style="width: 30em"
@@ -41,7 +41,7 @@
           </div>
           
           <div class="control-group">
-            <label class="control-label">${textContainer.text['subjectAssignPermissionActionLabel'] }</label>
+            <label for="permissionActionComboId" class="control-label">${textContainer.text['subjectAssignPermissionActionLabel'] }</label>
             <div class="controls">
             	                    	
               <grouper:combobox2 idBase="permissionActionCombo" style="width: 30em"
@@ -54,7 +54,7 @@
           </div>
           
           <div class="control-group">
-            <label class="control-label">${textContainer.text['subjectAssignPermissionRoleLabel'] }</label>
+            <label for="subjectRoleComboId" class="control-label">${textContainer.text['subjectAssignPermissionRoleLabel'] }</label>
             <div class="controls">
               <input type="hidden" name="typeOfGroup" value="role" />                   	
                <grouper:combobox2 idBase="subjectRoleCombo" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectDeleteAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectDeleteAudits.jsp
@@ -33,9 +33,9 @@
                     <option value="since">${textContainer.text['subjectResolutionSubjectDeleteLogFilterType_since']}</option>
                   </select>
                   (&nbsp;
-                  <input id="from-date" name="filterFromDate" type="text" placeholder="${textContainer.text['subjectResolutionSubjectDeleteLogFilterDatePlaceholder'] }" 
+                  <input id="from-date" aria-label="${textContainer.text['ariaLabelGuiFromDate']}" name="filterFromDate" type="text" placeholder="${textContainer.text['subjectResolutionSubjectDeleteLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp; ${textContainer.text['subjectResolutionSubjectDeleteLogFilterAndLabel'] }&nbsp;
-                  <input id="to-date" name="filterToDate" type="text" placeholder="${textContainer.text['subjectResolutionSubjectDeleteLogFilterDatePlaceholder'] }" 
+                  <input id="to-date" aria-label="${textContainer.text['ariaLabelGuiToDate']}" name="filterToDate" type="text" placeholder="${textContainer.text['subjectResolutionSubjectDeleteLogFilterDatePlaceholder'] }" 
                     class="span2">&nbsp;)
                   <label class="checkbox">
                     <input type="checkbox" name="showExtendedResults" value="true">${textContainer.text['subjectResolutionSubjectDeleteLogFilterShowExtendedResults']}

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectSearch.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectSearch.jsp
@@ -25,7 +25,7 @@
                     onsubmit="ajax('../app/UiV2SubjectResolution.searchSubjectsSubmit', {formIds: 'searchPageForm'}); return false;">
                   <div class="row-fluid">              
                     <div class="span2">
-                      <label for="searchFormSearch">${textContainer.text['find.search-for'] }</label>
+                      <label for="subjectSearchQueryId">${textContainer.text['find.search-for'] }</label>
                     </div>
                     <div class="span3" style="white-space: nowrap;">
                       
@@ -33,7 +33,7 @@
                           filterOperation="../app/UiV2SubjectResolution.addMemberFilter"/>
                         ${textContainer.text['miscellaneousSubjectResolutionSearchSubjectEntityLabel']} --%>
                         
-                       <input type="text" name="subjectId" placeholder="${textContainer.text['subjectResolutionSubjectsSearchQueryTextFieldPlaceholder']}"
+                       <input type="text" id="subjectSearchQueryId" name="subjectId" placeholder="${textContainer.text['subjectResolutionSubjectsSearchQueryTextFieldPlaceholder']}"
                         aria-label="${textContainer.text['ariaLabelSubjectResolutionSubjectsSearchQueryTextFieldPlaceholder']}">
                       
                     </div>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/unresolvedSubjectsHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/unresolvedSubjectsHelper.jsp
@@ -13,6 +13,7 @@
                         <th>
                           <label class="checkbox checkbox-no-padding">
                             <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.usduCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+                            <span class="sr-only">${textContainer.text['subjectResolutionCheckboxAriaLabel']}</span>
                           </label>
                         </th>
                       

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceCompare.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceCompare.jsp
@@ -74,7 +74,7 @@
                   </div>
                   
                   <div class="control-group">
-                    <label for="searchStringId" class="control-label">${textContainer.text['subjectSourcesCompareSearchString'] }</label>
+                    <label for="searchStringsId" class="control-label">${textContainer.text['subjectSourcesCompareSearchString'] }</label>
                     <div class="controls">
                       <textarea id="searchStringsId" name="searchStringsName" rows="5"></textarea>
                       <span class="help-block">${textContainer.text['subjectSourcesCompareSearchStringLabel'] }</span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set  value="${grouperRequestContainer.subjectSourceContainer.guiSubjectSourceConfiguration}" var="guiSubjectSourceConfiguration"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap; width: 30%;"><strong><label for="sourceConfigId">${textContainer.text['subjectSourceConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap; width: 30%;"><strong><label for="subjectSourceConfigId">${textContainer.text['subjectSourceConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap; width: 5%;">&nbsp;</td>
     <td>
       <span style="white-space: nowrap">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActionConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActionConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.userLifecycleContainer.guiUserLifecycleActionConfiguration}" var="guiUserLifecycleActionConfig"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecycleActionConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       
@@ -18,7 +18,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldTypeId">${textContainer.text['userLifecycleActionTypeLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecycleActionTypeId">${textContainer.text['userLifecycleActionTypeLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       <select name="userLifecycleActionType" id="userLifecycleActionTypeId" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.userLifecycleContainer.guiUserLifecycleEventConfiguration}" var="guiUserLifecycleEventConfig"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecycleEventConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       
@@ -18,7 +18,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldTypeId">${textContainer.text['userLifecycleEventTypeLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecycleEventTypeId">${textContainer.text['userLifecycleEventTypeLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       <select name="userLifecycleEventType" id="userLifecycleEventTypeId" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventsList.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventsList.jsp
@@ -39,6 +39,7 @@
           <th>
             <label class="checkbox checkbox-no-padding">
               <input type="checkbox" name="notImportantXyzName" id="notImportantXyzId" onchange="$('.eventCheckbox').prop('checked', $('#notImportantXyzId').prop('checked'));" />
+              <span class="sr-only">${textContainer.text['miscellaneousUserLifecycleEventsListMembershipCheckboxAriaLabel']}</span>
             </label>
           </th>
           <th>${textContainer.text['miscellaneousUserLifecycleEventsListHeaderGroupName']}</th>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.userLifecycleContainer.guiUserLifecyclePolicyConfiguration}" var="guiUserLifecyclePolicyConfig"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecyclePolicyConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       
@@ -18,7 +18,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldTypeId">${textContainer.text['userLifecyclePolicyTypeLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecyclePolicyTypeId">${textContainer.text['userLifecyclePolicyTypeLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       <select name="userLifecyclePolicyType" id="userLifecyclePolicyTypeId" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyPartConfigAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyPartConfigAddHelper.jsp
@@ -3,7 +3,7 @@
   <c:set value="${grouperRequestContainer.userLifecycleContainer.guiUserLifecyclePolicyPartConfiguration}" var="guiUserLifecyclePolicyPartConfig"/>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecyclePolicyPartConfigId">${textContainer.text['dataFieldConfigIdLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       
@@ -18,7 +18,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="dataFieldTypeId">${textContainer.text['userLifecyclePolicyPartTypeLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="userLifecyclePolicyPartTypeId">${textContainer.text['userLifecyclePolicyPartTypeLabel']}</label></strong></td>
     <td style="vertical-align: top; white-space: nowrap;">&nbsp;</td>
     <td>
       <select name="userLifecyclePolicyPartType" id="userLifecyclePolicyPartTypeId" style="width: 30em"

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/visualization/visualizationMain.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/visualization/visualizationMain.jsp
@@ -47,7 +47,7 @@
         <!-- parent levels -->
         <tr>
           <td style="vertical-align: top; white-space: nowrap;">
-            <strong><label for="vis-settings-parents-all">${textContainer.text['visualization.form.showParents']}:</label></strong>
+            <strong><label for="vis-settings-parents-levels">${textContainer.text['visualization.form.showParents']}:</label></strong>
           </td>
           <td>
             <input type="checkbox" name="drawNumParentsAll" id="vis-settings-parents-all" value="true" ${grouperRequestContainer.visualizationContainer.drawNumParentsLevels <= -1 ? "checked": ""} />
@@ -60,7 +60,7 @@
         <!-- child levels -->
         <tr>
           <td style="vertical-align: top; white-space: nowrap;">
-            <strong><label for="vis-settings-children-all">${textContainer.text['visualization.form.showChildren']}:</label></strong>
+            <strong><label for="vis-settings-children-levels">${textContainer.text['visualization.form.showChildren']}:</label></strong>
           </td>
           <td>
             <input type="checkbox" name="drawNumChildrenAll" id="vis-settings-children-all" value="true" ${grouperRequestContainer.visualizationContainer.drawNumChildrenLevels <= -1 ? "checked": ""} />
@@ -73,7 +73,7 @@
         <!-- sibling levels -->
         <tr>
           <td style="vertical-align: top; white-space: nowrap;">
-            <strong><label for="vis-settings-siblings-all">${textContainer.text['visualization.form.maxSiblings']}</label>:</strong>
+            <strong><label for="vis-settings-siblings">${textContainer.text['visualization.form.maxSiblings']}</label>:</strong>
           </td>
           <td>
             <input type="checkbox" name="drawMaxSiblingsAll" id="vis-settings-siblings-all" value="true" ${grouperRequestContainer.visualizationContainer.drawMaxSiblings <= 0 ? "checked": ""} />
@@ -199,10 +199,10 @@
   </div>
   <div class="modal-body">
     <form class="form form-inline" id="addVisualizationMemberSearchFormId">
-      <input name="addMemberSubjectSearch" type="text" placeholder=""/>
+      <input name="addMemberSubjectSearch" type="text" placeholder="" aria-label="${textContainer.textEscapeXml['groupSearchMemberOrId']}"/>
       <button class="btn" onclick="ajax('../app/UiV2Visualization.addMemberSearch?groupId=${grouperRequestContainer.groupContainer.guiGroup.group.id}', {formIds: 'addVisualizationMemberSearchFormId'}); return false;" >${textContainer.text['groupSearchButton'] }</button>
       <br />
-      <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
+      <span style="white-space: nowrap;"><input type="checkbox" name="matchExactId" value="true" aria-label="${textContainer.textEscapeXml['groupLabelExactIdMatch']}"/> ${textContainer.text['groupLabelExactIdMatch'] }</span>
       <br />
       <span style="white-space: nowrap;">${textContainer.text['find.search-source'] }
       <select name="sourceId">
@@ -239,7 +239,7 @@
   <span class="vis-fullscreen-open"><a href="javascript:openVisualizationModal()">${textContainer.text['visualization.graph.expand']}&nbsp;<i class="fa fa-expand"></i></a></span>
 
   <div id="vis-copy-dot-output" style="display: none">
-    <textarea id="vis-copy-dot-output-txt" cols="80" rows="20" style="width: 99%"></textarea>
+    <textarea id="vis-copy-dot-output-txt" aria-label="${textContainer.text['visualization.graph.copyDot']}" cols="80" rows="20" style="width: 99%"></textarea>
   </div>
 </div>
 <div id="vis-graph-svg-outer">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/workflowConfigObjectAddHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/workflowConfigObjectAddHelper.jsp
@@ -93,7 +93,7 @@
    </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigViewersGroupIdId">${textContainer.text['grouperWorkflowConfigViewersGroupIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigViewersGroupComboId">${textContainer.text['grouperWorkflowConfigViewersGroupIdLabel']}</label></strong></td>
     <td>
       <grouper:combobox2 idBase="grouperWorkflowConfigViewersGroupCombo" style="width: 30em" 
          value="${guiWorkflowConfig.grouperWorkflowConfig.workflowConfigViewersGroupId}"
@@ -105,7 +105,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigSendEmailId">${textContainer.text['grouperWorkflowConfigSendEmailLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkdlowConfigSendEmailId">${textContainer.text['grouperWorkflowConfigSendEmailLabel']}</label></strong></td>
     <td>
       <select name="grouperWorkflowConfigSendEmail" id="grouperWorkdlowConfigSendEmailId" style="width: 30em">
         <option value="false" ${guiWorkflowConfig.grouperWorkflowConfig.workflowConfigSendEmail ? '' : 'selected="selected"' } >${textContainer.textEscapeXml['grouperWorkflowConfigNoDoNotSendEmailLabel']}</option>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/workflowConfigObjectEditHelper.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/workflowConfigObjectEditHelper.jsp
@@ -87,7 +87,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigViewersGroupIdId">${textContainer.text['grouperWorkflowConfigViewersGroupIdLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigViewersGroupComboId">${textContainer.text['grouperWorkflowConfigViewersGroupIdLabel']}</label></strong></td>
     <td>
       <grouper:combobox2 idBase="grouperWorkflowConfigViewersGroupCombo" style="width: 30em" 
          value="${guiWorkflowConfig.grouperWorkflowConfig.workflowConfigViewersGroupId}"
@@ -99,7 +99,7 @@
   </tr>
   
   <tr>
-    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkflowConfigSendEmailId">${textContainer.text['grouperWorkflowConfigSendEmailLabel']}</label></strong></td>
+    <td style="vertical-align: top; white-space: nowrap;"><strong><label for="grouperWorkdlowConfigSendEmailId">${textContainer.text['grouperWorkflowConfigSendEmailLabel']}</label></strong></td>
     <td>
       <select name="grouperWorkflowConfigSendEmail" id="grouperWorkdlowConfigSendEmailId" style="width: 30em">
         <option value="false" ${guiWorkflowConfig.grouperWorkflowConfig.workflowConfigSendEmail ? '' : 'selected="selected"' } >${textContainer.textEscapeXml['grouperWorkflowConfigNoDoNotSendEmailLabel']}</option>

--- a/grouper-ui/webapp/grouperExternal/public/assets/js/grouperUi.js
+++ b/grouper-ui/webapp/grouperExternal/public/assets/js/grouperUi.js
@@ -2995,6 +2995,44 @@ function grouperRegisterCombobox(jquerySelector, url, additionalFormElementNames
 
   var ts = new TomSelect(jquerySelector, tomSelectOptions);
 
+  // Accessibility: a combobox is two inputs - the original (now hidden, class
+  // ts-hidden-accessible) and the visible control (id "<origId>-ts-control"). On init TomSelect
+  // RELOCATES the page's <label for="<origId>"> onto the visible control (rewriting it to
+  // for="<origId>-ts-control" and giving it id "<origId>-ts-label"), which labels the visible
+  // control but leaves the ORIGINAL input unlabeled - and WAVE flags that. So: read the label
+  // wherever it now is (relocated id, relocated for, or still on the original) and put an
+  // aria-label on the original; only label the visible control ourselves if TomSelect didn't.
+  // Wrapped in try/catch so an a11y enhancement can never break combobox initialization.
+  try {
+    var grouperTsOrig = ts.input;
+    if (grouperTsOrig && grouperTsOrig.id) {
+      var grouperTsOrigId = grouperTsOrig.id;
+      var grouperTsCtl = ts.control_input || document.getElementById(grouperTsOrigId + '-ts-control');
+      var grouperTsLabelEl = document.querySelector('label[for="' + grouperTsOrigId + '"]')
+          || document.getElementById(grouperTsOrigId + '-ts-label')
+          || document.querySelector('label[for="' + grouperTsOrigId + '-ts-control"]');
+      var grouperTsName = grouperTsOrig.getAttribute('aria-label')
+          || (grouperTsLabelEl ? (grouperTsLabelEl.textContent || '').replace(/\s+/g, ' ').trim() : '')
+          || grouperTsOrig.getAttribute('placeholder')
+          || '';
+      if (grouperTsName) {
+        // The original input lost its label to TomSelect's relocation - name it directly.
+        if (!grouperTsOrig.getAttribute('aria-label')) {
+          grouperTsOrig.setAttribute('aria-label', grouperTsName);
+        }
+        // Only name the visible control if TomSelect left it without any label association.
+        if (grouperTsCtl && !grouperTsCtl.getAttribute('aria-label') && !grouperTsCtl.getAttribute('aria-labelledby')
+            && !(grouperTsCtl.id && document.querySelector('label[for="' + grouperTsCtl.id + '"]'))) {
+          grouperTsCtl.setAttribute('aria-label', grouperTsName);
+        }
+      }
+    }
+  } catch (grouperTsAriaErr) {
+    if (window.console && console.warn) {
+      console.warn('combobox aria-label setup failed', grouperTsAriaErr);
+    }
+  }
+
   // Remember ajax config on the instance so programmatic setters don't need url/extra params.
   ts._grouperUrl = url;
   ts._grouperExtraUrlOptions = extraUrlOptions;

--- a/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
+++ b/grouper/conf/grouperText/grouper.textNg.en.us.base.properties
@@ -2407,6 +2407,9 @@ ariaLabelGuiMoreOptions = Show more options
 ariaLabelGuiRefreshFolderBrowse = Refresh folder browse
 ariaLabelGuiEntityName = Enter entity name
 ariaLabelGuiSearch = Search
+ariaLabelGuiSelectAll = Select all
+ariaLabelGuiFromDate = From date
+ariaLabelGuiToDate = To date
 
 # when there is a subject not found, but the subject id is known
 guiSubjectNotFound = Entity not found: ${grouperRequestContainer.commonRequestContainer.subjectId}
@@ -3991,7 +3994,7 @@ subjectPermissionPageTitle = Subject permissions
 
 attributePrivilegesPageTitle = Attribute privileges
 
-grouperHomePageTitle = 
+grouperHomePageTitle = Home
 
 globalAttributeResolverConfigsPageTitle = Global entity resolvers
 
@@ -19540,6 +19543,8 @@ guiCustomUiTableTextEndIfMatches = End if matches
 
 
 guiAbbreviateShow = more
+
+guiAbbreviateTextareaAriaLabel = Full text
 
 guiCustomUiSelectUser = Select user
 


### PR DESCRIPTION
Adds programmatic labels (label-for, aria-label, sr-only, and matching ids) to form controls across the Grouper UI that WAVE flagged as "Missing form label" — table filters, select-all checkboxes, audit date inputs, config/admin selects, the add-member widget, attribute-def new/edit, the TomSelect combobox (grouperUi.js), and the abbreviate-textarea tag. Driven by running WAVE on each screen. Excludes the pre-existing dual-layout "Multiple form labels" on privilege/members filters (separate follow-up).