### PR TITLE
GRP-7087: Accessibility: missing or uninformative page title (all pages but e.g. new datafield)

### DIFF
--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('daemonJobsAddDaemon')}
 
 		<c:set value="${grouperRequestContainer.adminContainer.guiGrouperDaemonConfiguration}" var="guiGrouperDaemonConfiguration"/>
             <div class="bread-header-container">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminDaemonJobEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('daemonJobsEditDaemon')}
 			<c:set value="${grouperRequestContainer.adminContainer.guiGrouperDaemonConfiguration}" var="guiGrouperDaemonConfiguration"/>
             <div class="bread-header-container">
                <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminInstrumentationInstance.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminInstrumentationInstance.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('adminInstrumentationTitle')}
 
             <c:set var="guiInstance" value="${grouperRequestContainer.adminContainer.guiInstrumentationDataInstances[0]}" />
             

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminJobHistoryChart.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminJobHistoryChart.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('adminJobHistoryChart')}
 
 <script src="../../grouperExternal/public/assets/js/gantt-chart-d3.js" charset="utf-8"></script>
 <script src="../../grouperExternal/public/assets/js/grouperJobChart.js" type="text/javascript"></script>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminSubjectApiDiagnostics.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/admin/adminSubjectApiDiagnostics.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('adminSubjectApiDiagnosticsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefDelete.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefDelete.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefDeleteTitle', grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDef/attributeDefEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefEditTitle', grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.displayName)}
 
 
             <%-- for the new group or new stem button --%>
@@ -56,7 +57,7 @@
                        <table class="attributeDefAssignToTable">
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToAttributeDef" id="attributeDefToEditAssignToAttributeDefId"
+                             <input type="checkbox" name="attributeDefToEditAssignToAttributeDef" id="attributeDefToEditAssignToAttributeDefId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.attributeDef']}"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToAttributeDefDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToAttributeDefId">
@@ -64,7 +65,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToAttributeDefAssign" id="attributeDefToEditAssignToAttributeDefAssignId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToAttributeDefAssign" id="attributeDefToEditAssignToAttributeDefAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.attributeDefAssign']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToAttributeDefAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -75,7 +76,7 @@
                          </tr>
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToStem" id="attributeDefToEditAssignToStemId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToStem" id="attributeDefToEditAssignToStemId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.stem']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToStemDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox" for="attributeDefToEditAssignToStemId">
@@ -83,7 +84,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToStemAssign" id="attributeDefToEditAssignToStemAssignId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToStemAssign" id="attributeDefToEditAssignToStemAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.stemAssign']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToStemAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -94,7 +95,7 @@
                          </tr>
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToGroup" id="attributeDefToEditAssignToGroupId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToGroup" id="attributeDefToEditAssignToGroupId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.group']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToGroupDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToGroupId">
@@ -102,7 +103,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToGroupAssign" id="attributeDefToEditAssignToGroupAssignId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToGroupAssign" id="attributeDefToEditAssignToGroupAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.groupAssign']}" 
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToGroupAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -113,7 +114,7 @@
                          </tr>
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToMember" id="attributeDefToEditAssignToMemberId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToMember" id="attributeDefToEditAssignToMemberId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.member']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToMemberDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMemberId">
@@ -121,7 +122,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToMemberAssign" id="attributeDefToEditAssignToMemberAssignId"
+                             <input type="checkbox" name="attributeDefToEditAssignToMemberAssign" id="attributeDefToEditAssignToMemberAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.memberAssign']}"
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToMemberAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -132,7 +133,7 @@
                          </tr>
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToMembership" id="attributeDefToEditAssignToMembershipId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToMembership" id="attributeDefToEditAssignToMembershipId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.membership']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToEffMembershipDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToMembershipId">
@@ -140,7 +141,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToMembershipAssign" id="attributeDefToEditAssignToMembershipAssignId"
+                             <input type="checkbox" name="attributeDefToEditAssignToMembershipAssign" id="attributeDefToEditAssignToMembershipAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.membershipAssign']}"
                                class="assignToCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToEffMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -151,7 +152,7 @@
                          </tr>
                          <tr>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToLeft">
-                             <input type="checkbox" name="attributeDefToEditAssignToImmediateMembership" id="attributeDefToEditAssignToImmediateMembershipId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToImmediateMembership" id="attributeDefToEditAssignToImmediateMembershipId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.immediateMembership']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToImmMembershipDb == 'T' ? 'checked="checked"' : '' } />
                              <label class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox" for="attributeDefToEditAssignToImmediateMembershipId">
@@ -159,7 +160,7 @@
                              </label>
                            </td>
                            <td class="attributeAssignAssignToTd attributeAssignAssignToRight">
-                             <input type="checkbox" name="attributeDefToEditAssignToImmediateMembershipAssign" id="attributeDefToEditAssignToImmediateMembershipAssignId" 
+                             <input type="checkbox" name="attributeDefToEditAssignToImmediateMembershipAssign" id="attributeDefToEditAssignToImmediateMembershipAssignId" aria-label="${textContainer.textEscapeXml['attributeDefAssignTo.immediateMembershipAssign']}" 
                                class="assignToCheckbox assignToLimitHideCheckbox assignToPermHideCheckbox assignToServiceHideCheckbox assignToTypeHideCheckbox"
                                onclick="showHideMarkerSection()"
                                value="true" ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.assignToImmMembershipAssnDb == 'T' ? 'checked="checked"' : '' } />
@@ -178,7 +179,7 @@
                     <label for="attributeDefMultiAssignable" class="control-label">${textContainer.text['attributeDefMultiAssignable'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiAssignable" id="attributeDefMultiAssignable" value="true" 
+                      <input type="checkbox" name="attributeDefMultiAssignable" id="attributeDefMultiAssignable" value="true"
                          ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.multiAssignableDb == 'T' ? 'checked="checked"' : '' }
                       />
                       <span class="help-block">${textContainer.text['attributeDefMultiAssignableDescription'] }</span>
@@ -208,7 +209,7 @@
                     <label for="attributeDefMultiValued" class="control-label">${textContainer.text['attributeDefMultiValued'] }</label>
                     <div class="controls">
                     
-                      <input type="checkbox" name="attributeDefMultiValued" id="attributeDefMultiValued" 
+                      <input type="checkbox" name="attributeDefMultiValued" id="attributeDefMultiValued"
                         ${grouperRequestContainer.attributeDefContainer.guiAttributeDef.attributeDef.multiValuedDb == 'T' ? 'checked="checked"' : '' }
                       value="true" />
                       <span class="help-block">${textContainer.text['attributeDefMultiValuedDescription'] }</span>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActionEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/attributeDefActionEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefActionEditTitle', attributeUpdateRequestContainer.action)}
 
 
             <%-- for the new group or new stem button --%>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/newAttributeDefAction.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefAction/newAttributeDefAction.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('attributeActionNewBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameDelete.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameDelete.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefNameDeleteTitle', grouperRequestContainer.attributeDefNameContainer.guiAttributeDefName.attributeDefName.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.attributeDefNameContainer.guiAttributeDefName.attributeDefName.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefNameEditTitle', grouperRequestContainer.attributeDefNameContainer.guiAttributeDefName.attributeDefName.displayName)}
 
 
             <%-- for the new group or new stem button --%>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameInheritance.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/attributeDefName/attributeDefNameInheritance.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('attributeDefNameEditTitle', grouperRequestContainer.attributeDefNameContainer.guiAttributeDefName.attributeDefName.displayName)}
 
 
             <%-- for the new group or new stem button --%>

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/editWsTrustedJwtConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/editWsTrustedJwtConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousWsTrustedJwtEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwtConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwtConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousWsTrustedJwtAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwts.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/authentication/wsTrustedJwts.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousWsTrustedJwtsOverallBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileAddEntry.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileAddEntry.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousConfigurationFilesAddEntryBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileImport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configurationFileImport.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousConfigurationFilesImportBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configure.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/configure.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousConfigurationFilesBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/configure/history.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/configure/history.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousConfigurationFilesHistoryBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/customUi/customUiConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/customUi/customUiConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousCustomUiAddBreadcrumb')}
 
 	 <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/customUi/editCustomUiConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/customUi/editCustomUiConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousCustomUiEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUser.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningUser.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDeprovisioningOverallBreadcrumb')}
 <%-- --%>
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningViewRecent.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/deprovisioning/deprovisioningViewRecent.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDeprovisioningOverallBreadcrumb')}
 <%-- --%>
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataFieldConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataFieldConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataFieldsAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderChangeLogQueryConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderChangeLogQueryConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderChangeLogQueryAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderQueryConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataProviderQueryConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderQueryAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataRowConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/dataRowConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataRowsAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataFieldConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataFieldConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataFieldEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderChangeLogQueryConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderChangeLogQueryConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderChangeLogQueryEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderQueryConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataProviderQueryConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderQueryEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataRowConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editDataRowConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataRowEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editPrivacyRealmConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/editPrivacyRealmConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousPrivacyRealmEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataFields.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataFields.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataFieldsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataFieldsSummary.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataFieldsSummary.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousEntityDataFieldsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviderChangeLogQueries.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviderChangeLogQueries.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderChangeLogQueriesBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviderQueries.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviderQueries.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProviderQueriesBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviders.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataProviders.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataProvidersBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataRows.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/entityDataRows.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousDataRowsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/privacyRealmConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/privacyRealmConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousPrivacyRealmAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/privacyRealms.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/entityDataFields/privacyRealms.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousPrivacyRealmsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalEntities/invite.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalEntities/invite.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('groupImportMembersBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalSubjectSelfRegister/externalSubjectSelfRegister.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalSubjectSelfRegister/externalSubjectSelfRegister.jsp
@@ -1,6 +1,7 @@
 <!-- Start: externalSubjectSelfRegister/externalSubjectSelfRegister.jsp: main page -->
 
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('externalSubjectSelfRegister.registerTitle')}
 
 <div class="bread-header-container">
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/editExternalSystemConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/editExternalSystemConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGrouperExternalSystemsEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/externalSystemAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/externalSystemAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGrouperExternalSystemsAddBreadcrumb')}
 
   <c:set  value="${grouperRequestContainer.externalSystemContainer.guiGrouperExternalSystem}" var="guiGrouperExternalSystem"/>
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/viewExternalSystemConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/externalSystems/viewExternalSystemConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGrouperExternalSystemsViewDetailsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/globalAttributeResolver/editGlobalAttributeResolverConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/globalAttributeResolver/editGlobalAttributeResolverConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGlobalAttributeResolverConfigEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/globalAttributeResolver/globalAttributeResolverConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/globalAttributeResolver/globalAttributeResolverConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGlobalAttributeResolverConfigAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupAttestationOverallSettings.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupAttestationOverallSettings.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousAttestationOverallBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEditCompositeProgress.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/group/groupEditCompositeProgress.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('groupEditCompositeTitle', grouperRequestContainer.groupContainer.guiGroup.group.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/groupImport/groupImportReport.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/groupImport/groupImportReport.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('groupImportMembersBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/editGshTemplateConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/editGshTemplateConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGshTemplatesEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/gshTemplateConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/gshTemplate/gshTemplateConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGshTemplatesAddBreadcrumb')}
 
 	 <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/index/help.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/index/help.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('grouper.help')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/index/search.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/index/search.jsp
@@ -1,6 +1,7 @@
 <!-- ./webapp/WEB-INF/grouperUi2/index/index.jsp -->
 
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('searchBreadcrumb')}
               <grouper:browserPage jspName="search" />
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityDelete.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityDelete.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('localEntityDeleteTitle', grouperRequestContainer.groupContainer.guiGroup.group.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/localEntity/localEntityEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('localEntityEditTitle', grouperRequestContainer.groupContainer.guiGroup.group.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membership/editMembership.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membership/editMembership.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('membershipEditSubHeader', grouperRequestContainer.subjectContainer.guiSubject.screenLabelShort2noLink)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceAttributeDefPrivileges.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceAttributeDefPrivileges.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('privilegesTraceBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceMembership.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceMembership.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('membershipTraceBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membership/tracePrivileges.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membership/tracePrivileges.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('privilegesTraceBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceStemPrivileges.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/membership/traceStemPrivileges.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('privilegesTraceBreadcrumb')}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.stemContainer.guiStem.stem.id}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myGroups/myGroupsJoin.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myGroups/myGroupsJoin.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('myGroupsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myGroups/myGroupsMemberships.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myGroups/myGroupsMemberships.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('myGroupsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingAttributesImanage.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingAttributesImanage.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('myStemsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingGroupsImanage.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/myStems/myStemsContainingGroupsImanage.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('myStemsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/assignments.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/assignments.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigurationsAssignmentsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/groupsProvisionable.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/groupsProvisionable.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigurationsGroupsProvisionableBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigAddBreadcrumb')}
    <c:set  value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration"/>
 	 <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigDetailsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigEditBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigJobDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigJobDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigurationsJobDetailsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigJobs.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigJobs.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigurationsJobsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigLogs.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigLogs.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigurationsLogsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigRunFullSync.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigRunFullSync.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigRunFullSyncBreadcrumb')}
 
 	 <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewActivity.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewActivity.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigViewActivityBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewErrors.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerConfigViewErrors.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousProvisionerConfigViewErrorsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerDiagnostics.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerDiagnostics.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGrouperProvisioningDiagnosticsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerDiagnosticsInit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/provisionerConfigs/provisionerDiagnosticsInit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousGrouperProvisioningDiagnosticsBreadcrumb')}
 
    <c:set value="${grouperRequestContainer.provisionerConfigurationContainer.guiProvisionerConfiguration}" var="guiProvisionerConfiguration" />
 

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/role/roleInheritance.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/role/roleInheritance.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('roleInheritanceEditTitle', grouperRequestContainer.groupContainer.guiGroup.group.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.groupContainer.guiGroup.group.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/service/viewService.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/service/viewService.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('viewServiceHeaderLabel', grouperRequestContainer.serviceContainer.guiService.guiAttributeDefName.attributeDefName.displayName)}
 
             <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.serviceContainer.guiService.guiAttributeDefName.attributeDefName.stem.id}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/sqlSync/editSqlSyncConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/sqlSync/editSqlSyncConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSqlSyncEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/sqlSync/sqlSyncConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/sqlSync/sqlSyncConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSqlSyncAddBreadcrumb')}
 
 	 <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemEditProgress.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/stem/stemEditProgress.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:titleFromKeyAndText('stemEditTitle', grouperRequestContainer.stemContainer.guiStem.stem.displayName)}
  
              <%-- for the new group or new stem button --%>
             <input type="hidden" name="objectStemId" value="${grouperRequestContainer.stemContainer.guiStem.stem.parentUuid}" />

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectDeleteAudits.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectDeleteAudits.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectResolutionAuditsBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectSearch.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/subjectSearch.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectResolutionSubjectSearchBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/unresolvedSubjects.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectResolution/unresolvedSubjects.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectResolutionSubjectUnresolvedBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectSourceConfigAddBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceCompare.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceCompare.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectSourceConfigCompareBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceEdit.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/subjectSource/subjectSourceEdit.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousSubjectSourceConfigEditBreadcrumb')}
 
  <div class="bread-header-container">
    <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecycleActionConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecycleActionConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleActionEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecycleEventConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecycleEventConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleEventEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecyclePolicyConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecyclePolicyConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePolicyEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecyclePolicyPartConfigDetails.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/editUserLifecyclePolicyPartConfigDetails.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePolicyPartEditBreadcrumb')}
 
             <div class="bread-header-container">
               <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActionConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActionConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleActionsAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActions.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleActions.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleActionsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleEventsAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEvents.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEvents.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleEventsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventsList.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleEventsList.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleEventsListBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicies.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicies.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePoliciesBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePoliciesAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyPartConfigAdd.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyPartConfigAdd.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePolicyPartsAddBreadcrumb')}
 
    <div class="bread-header-container">
        <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyParts.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecyclePolicyParts.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecyclePolicyPartsBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleSummary.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/userLifecycle/userLifecycleSummary.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('miscellaneousUserLifecycleBreadcrumb')}
 
 <div class="bread-header-container">
   <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowInstancesSubjectInitiated.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowInstancesSubjectInitiated.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('workflowMiscFormsSubjectInitiatedTitle')}
 
    <div class="bread-header-container">
      <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowViewInstance.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowViewInstance.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('workflowMiscFormsWaitingForApprovalTitle')}
 
    <div class="bread-header-container">
      <ul class="breadcrumb">

--- a/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowWaitingForApprovals.jsp
+++ b/grouper-ui/webapp/WEB-INF/grouperUi2/workflow/grouperWorkflowWaitingForApprovals.jsp
@@ -1,4 +1,5 @@
 <%@ include file="../assetsJsp/commonTaglib.jsp"%>
+${grouper:title('workflowMiscFormsWaitingForApprovalTitle')}
 
    <div class="bread-header-container">
      <ul class="breadcrumb">


### PR DESCRIPTION
Adds accessible page titles across the Grouper UI so screen readers announce a meaningful, unique title on each page (previously many pages had a missing or generic title). Applies the grouper:title / grouper:titleFromKeyAndText tag to ~108 UI JSPs. Also adds aria-labels to the assign-to checkboxes on the attribute definition edit page. JIRA: https://todos.internet2.edu/browse/GRP-7087